### PR TITLE
👷‍♂️🐛 Converts YAML Sequence to JSON Array

### DIFF
--- a/azure-pipelines/Master/index.yml
+++ b/azure-pipelines/Master/index.yml
@@ -4,59 +4,60 @@ name: "$(BuildDefinitionName)_$(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)"
 
 variables:
 # If you want a project to be deployed as a package, make sure it is in this list.
-  packageProjects:
-  - "FGS.Collections.Extensions.Pagination"
-  - "FGS.Collections.Extensions.Pagination.Abstractions"
-  - "FGS.ComponentModel.DataAnnotations"
-  - "FGS.ComponentModel.DataAnnotations.Extensions"
-  - "FGS.Configuration.Abstractions"
-  - "FGS.Extensions.Configuration.AWS.ElasticBeanstalk.IisEnv"
-  - "FGS.Extensions.DependencyInjection.Autofac"
-  - "FGS.Extensions.Diagnostics.HealthChecks.EntityFramework"
-  - "FGS.Extensions.Logging.Serilog"
-  - "FGS.FaultHandling.Abstractions"
-  - "FGS.FaultHandling.Polly"
-  - "FGS.FaultHandling.Predicates.Mssql"
-  - "FGS.FaultHandling.Predicates.Win32"
-  - "FGS.FaultHandling.Primitives"
-  - "FGS.Interception.Abstractions"
-  - "FGS.Interception.Annotations.FaultHandling"
-  - "FGS.Interception.Annotations.Time"
-  - "FGS.Interception.DynamicProxy"
-  - "FGS.Interceptors.FaultHandling"
-  - "FGS.Interceptors.Time"
-  - "FGS.Linq.Expressions"
-  - "FGS.Primitives.Extensions"
-  - "FGS.Primitives.Time"
-  - "FGS.Primitives.Time.Abstractions"
-  - "FGS.Reflection.Extensions"
-  - "FGS.Rx.Extensions"
-  - "FGS.Rx.Extensions.Abstractions"
-  - "FGS.Tests.Support"
-  - "FGS.Tests.Support.AspNetCore.Mvc"
-  - "FGS.Tests.Support.Autofac.Mocking"
-  - "FGS.Tests.Support.Autofac.Mocking.Configuration"
-  - "FGS.Tests.Support.Autofac.Mocking.Logging"
-  - "FGS.Tests.Support.Autofac.Mocking.Options"
-  - "FGS.Tests.Support.AutoFixture.Mocking"
-  - "FGS.Tests.Support.AutoFixture.Mocking.Options"
-  - "FGS.AspNetCore.Hosting.Extensions.DependencyInjection.Autofac"
-  - "FGS.AspNetCore.Hosting.Extensions.Logging.Serilog"
-  - "FGS.AspNetCore.Http.Extensions.AWS.ALB"
-  - "FGS.AspNetCore.Http.Extensions.RequestStopwatch"
-  - "FGS.AspNetCore.Mvc.ModelBinding"
-  - "FGS.AspNetCore.Mvc.ModelBinding.Validation"
-  - "FGS.Autofac.AspNetCore.Mvc.Routing"
-  - "FGS.Autofac.CompositionRoot"
-  - "FGS.Autofac.CompositionRoot.Abstractions"
-  - "FGS.Autofac.DynamicScoping"
-  - "FGS.Autofac.DynamicScoping.Abstractions"
-  - "FGS.Autofac.Interception.DynamicProxy"
-  - "FGS.Autofac.Interceptors.FaultHandling"
-  - "FGS.Autofac.Interceptors.Time"
-  - "FGS.Autofac.Options"
-  - "FGS.Autofac.Registration.Extensions"
-  - "FGS.Collections.Extensions"
+  packageProjects: [
+  "FGS.Collections.Extensions.Pagination",
+  "FGS.Collections.Extensions.Pagination.Abstractions",
+  "FGS.ComponentModel.DataAnnotations",
+  "FGS.ComponentModel.DataAnnotations.Extensions",
+  "FGS.Configuration.Abstractions",
+  "FGS.Extensions.Configuration.AWS.ElasticBeanstalk.IisEnv",
+  "FGS.Extensions.DependencyInjection.Autofac",
+  "FGS.Extensions.Diagnostics.HealthChecks.EntityFramework",
+  "FGS.Extensions.Logging.Serilog",
+  "FGS.FaultHandling.Abstractions",
+  "FGS.FaultHandling.Polly",
+  "FGS.FaultHandling.Predicates.Mssql",
+  "FGS.FaultHandling.Predicates.Win32",
+  "FGS.FaultHandling.Primitives",
+  "FGS.Interception.Abstractions",
+  "FGS.Interception.Annotations.FaultHandling",
+  "FGS.Interception.Annotations.Time",
+  "FGS.Interception.DynamicProxy",
+  "FGS.Interceptors.FaultHandling",
+  "FGS.Interceptors.Time",
+  "FGS.Linq.Expressions",
+  "FGS.Primitives.Extensions",
+  "FGS.Primitives.Time",
+  "FGS.Primitives.Time.Abstractions",
+  "FGS.Reflection.Extensions",
+  "FGS.Rx.Extensions",
+  "FGS.Rx.Extensions.Abstractions",
+  "FGS.Tests.Support",
+  "FGS.Tests.Support.AspNetCore.Mvc",
+  "FGS.Tests.Support.Autofac.Mocking",
+  "FGS.Tests.Support.Autofac.Mocking.Configuration",
+  "FGS.Tests.Support.Autofac.Mocking.Logging",
+  "FGS.Tests.Support.Autofac.Mocking.Options",
+  "FGS.Tests.Support.AutoFixture.Mocking",
+  "FGS.Tests.Support.AutoFixture.Mocking.Options",
+  "FGS.AspNetCore.Hosting.Extensions.DependencyInjection.Autofac",
+  "FGS.AspNetCore.Hosting.Extensions.Logging.Serilog",
+  "FGS.AspNetCore.Http.Extensions.AWS.ALB",
+  "FGS.AspNetCore.Http.Extensions.RequestStopwatch",
+  "FGS.AspNetCore.Mvc.ModelBinding",
+  "FGS.AspNetCore.Mvc.ModelBinding.Validation",
+  "FGS.Autofac.AspNetCore.Mvc.Routing",
+  "FGS.Autofac.CompositionRoot",
+  "FGS.Autofac.CompositionRoot.Abstractions",
+  "FGS.Autofac.DynamicScoping",
+  "FGS.Autofac.DynamicScoping.Abstractions",
+  "FGS.Autofac.Interception.DynamicProxy",
+  "FGS.Autofac.Interceptors.FaultHandling",
+  "FGS.Autofac.Interceptors.Time",
+  "FGS.Autofac.Options",
+  "FGS.Autofac.Registration.Extensions",
+  "FGS.Collections.Extensions"
+  ]
 
 # This job is setup to only build on commits to `master`
 # _when files in the projects we're going to pack_ are changed. This is intended


### PR DESCRIPTION
It is unclear if the type difference matters to the YAML parser that Azure Pipelines uses. The previous syntax was yielding the error `A sequence was not expected`, and [the documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops#iterative-insertion) shows the bracketed syntax.