### PR TITLE
👷‍♂️🐛 Corrects Iterative Insertion

### DIFF
--- a/azure-pipelines/Master/index.yml
+++ b/azure-pipelines/Master/index.yml
@@ -2,7 +2,7 @@
 # version numbers for NuGet, when using the `byBuildNumber` versioning scheme.
 name: "$(BuildDefinitionName)_$(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)"
 
-variables:
+parameters:
 # If you want a project to be deployed as a package, make sure it is in this list.
   packageProjects: [
   "FGS.Collections.Extensions.Pagination",
@@ -82,7 +82,7 @@ stages:
 - stage: Deploy
   displayName: Deploy
   jobs:
-  - ${{ each packageProject in variables.packageProjects  }}:
+  - ${{ each packageProject in parameters.packageProjects  }}:
     - template: ./BuildAndPushPackage.yml
       parameters:
         project: ${{ packageProject }}


### PR DESCRIPTION
Per [the documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops#iterative-insertion), a `sequence` is an acceptable type for the iterative insertion syntax, however a previous implementation has assumed that a `sequence`-typed child of `variables` would work as the input. Instead, the documentation demonstrates them as children of `parameters`, which may be an important detail. This switches the usage as our latest attempt to correct the error `A sequence was not expected`.