### PR TITLE
👷🐛 Makes Deployment Pipeline's `Deploy` Stage into Template

### DIFF
--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -1,26 +1,84 @@
 parameters:
-  project: ""
+# If you want a project to be deployed as a package, make sure it is in this list.
+  packageProjects:
+  - FGS.Collections.Extensions.Pagination
+  - FGS.Collections.Extensions.Pagination.Abstractions
+  - FGS.ComponentModel.DataAnnotations
+  - FGS.ComponentModel.DataAnnotations.Extensions
+  - FGS.Configuration.Abstractions
+  - FGS.Extensions.Configuration.AWS.ElasticBeanstalk.IisEnv
+  - FGS.Extensions.DependencyInjection.Autofac
+  - FGS.Extensions.Diagnostics.HealthChecks.EntityFramework
+  - FGS.Extensions.Logging.Serilog
+  - FGS.FaultHandling.Abstractions
+  - FGS.FaultHandling.Polly
+  - FGS.FaultHandling.Predicates.Mssql
+  - FGS.FaultHandling.Predicates.Win32
+  - FGS.FaultHandling.Primitives
+  - FGS.Interception.Abstractions
+  - FGS.Interception.Annotations.FaultHandling
+  - FGS.Interception.Annotations.Time
+  - FGS.Interception.DynamicProxy
+  - FGS.Interceptors.FaultHandling
+  - FGS.Interceptors.Time
+  - FGS.Linq.Expressions
+  - FGS.Primitives.Extensions
+  - FGS.Primitives.Time
+  - FGS.Primitives.Time.Abstractions
+  - FGS.Reflection.Extensions
+  - FGS.Rx.Extensions
+  - FGS.Rx.Extensions.Abstractions
+  - FGS.Tests.Support
+  - FGS.Tests.Support.AspNetCore.Mvc
+  - FGS.Tests.Support.Autofac.Mocking
+  - FGS.Tests.Support.Autofac.Mocking.Configuration
+  - FGS.Tests.Support.Autofac.Mocking.Logging
+  - FGS.Tests.Support.Autofac.Mocking.Options
+  - FGS.Tests.Support.AutoFixture.Mocking
+  - FGS.Tests.Support.AutoFixture.Mocking.Options
+  - FGS.AspNetCore.Hosting.Extensions.DependencyInjection.Autofac
+  - FGS.AspNetCore.Hosting.Extensions.Logging.Serilog
+  - FGS.AspNetCore.Http.Extensions.AWS.ALB
+  - FGS.AspNetCore.Http.Extensions.RequestStopwatch
+  - FGS.AspNetCore.Mvc.ModelBinding
+  - FGS.AspNetCore.Mvc.ModelBinding.Validation
+  - FGS.Autofac.AspNetCore.Mvc.Routing
+  - FGS.Autofac.CompositionRoot
+  - FGS.Autofac.CompositionRoot.Abstractions
+  - FGS.Autofac.DynamicScoping
+  - FGS.Autofac.DynamicScoping.Abstractions
+  - FGS.Autofac.Interception.DynamicProxy
+  - FGS.Autofac.Interceptors.FaultHandling
+  - FGS.Autofac.Interceptors.Time
+  - FGS.Autofac.Options
+  - FGS.Autofac.Registration.Extensions
+  - FGS.Collections.Extensions
 
-jobs:
-- job: Build_and_Push_Package
-  displayName: Build & Push Package for "${{ parameters.project }}"
-  pool:
-    vmImage: 'windows-latest'
+stages:
 
-  steps:
+- stage: Deploy
+  displayName: Deploy
+  jobs:
+  - ${{ each project in parameters.packageProjects }}:
+    - job: Build_and_Push_Package__${{ project }}
+      displayName: Build & Push Package for "${{ project }}"
+      pool:
+        vmImage: 'windows-latest'
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet pack "src/${{ parameters.project }}/${{ parameters.project }}.csproj"
-    inputs:
-      command: pack
-      packagesToPack: "src/${{ parameters.project }}/${{ parameters.project }}.csproj"
-      versioningScheme: byBuildNumber
-      arguments: --configuration Release
+      steps:
 
-  - task: NuGetCommand@2
-    displayName: nuget push "src/${{ parameters.project }}/${{ parameters.project }}.csproj"
-    inputs:
-      command: push
-      packagesToPush: "src/${{ parameters.project }}/**/*.nupkg;!src/${{ parameters.project }}/**/*.symbols.nupkg"
-      nuGetFeedType: external
-      publishFeedCredentials: "NuGet foxguardsolutions Push All FGS.*"
+      - task: DotNetCoreCLI@2
+        displayName: dotnet pack "src/${{ project }}/${{ project }}.csproj"
+        inputs:
+          command: pack
+          packagesToPack: "src/${{ project }}/${{ project }}.csproj"
+          versioningScheme: byBuildNumber
+          arguments: --configuration Release
+
+      - task: NuGetCommand@2
+        displayName: nuget push "src/${{ project }}/${{ project }}.csproj"
+        inputs:
+          command: push
+          packagesToPush: "src/${{ project }}/**/*.nupkg;!src/${{ project }}/**/*.symbols.nupkg"
+          nuGetFeedType: external
+          publishFeedCredentials: "NuGet foxguardsolutions Push All FGS.*"

--- a/azure-pipelines/Master/index.yml
+++ b/azure-pipelines/Master/index.yml
@@ -2,63 +2,6 @@
 # version numbers for NuGet, when using the `byBuildNumber` versioning scheme.
 name: "$(BuildDefinitionName)_$(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)"
 
-parameters:
-# If you want a project to be deployed as a package, make sure it is in this list.
-  packageProjects: [
-  "FGS.Collections.Extensions.Pagination",
-  "FGS.Collections.Extensions.Pagination.Abstractions",
-  "FGS.ComponentModel.DataAnnotations",
-  "FGS.ComponentModel.DataAnnotations.Extensions",
-  "FGS.Configuration.Abstractions",
-  "FGS.Extensions.Configuration.AWS.ElasticBeanstalk.IisEnv",
-  "FGS.Extensions.DependencyInjection.Autofac",
-  "FGS.Extensions.Diagnostics.HealthChecks.EntityFramework",
-  "FGS.Extensions.Logging.Serilog",
-  "FGS.FaultHandling.Abstractions",
-  "FGS.FaultHandling.Polly",
-  "FGS.FaultHandling.Predicates.Mssql",
-  "FGS.FaultHandling.Predicates.Win32",
-  "FGS.FaultHandling.Primitives",
-  "FGS.Interception.Abstractions",
-  "FGS.Interception.Annotations.FaultHandling",
-  "FGS.Interception.Annotations.Time",
-  "FGS.Interception.DynamicProxy",
-  "FGS.Interceptors.FaultHandling",
-  "FGS.Interceptors.Time",
-  "FGS.Linq.Expressions",
-  "FGS.Primitives.Extensions",
-  "FGS.Primitives.Time",
-  "FGS.Primitives.Time.Abstractions",
-  "FGS.Reflection.Extensions",
-  "FGS.Rx.Extensions",
-  "FGS.Rx.Extensions.Abstractions",
-  "FGS.Tests.Support",
-  "FGS.Tests.Support.AspNetCore.Mvc",
-  "FGS.Tests.Support.Autofac.Mocking",
-  "FGS.Tests.Support.Autofac.Mocking.Configuration",
-  "FGS.Tests.Support.Autofac.Mocking.Logging",
-  "FGS.Tests.Support.Autofac.Mocking.Options",
-  "FGS.Tests.Support.AutoFixture.Mocking",
-  "FGS.Tests.Support.AutoFixture.Mocking.Options",
-  "FGS.AspNetCore.Hosting.Extensions.DependencyInjection.Autofac",
-  "FGS.AspNetCore.Hosting.Extensions.Logging.Serilog",
-  "FGS.AspNetCore.Http.Extensions.AWS.ALB",
-  "FGS.AspNetCore.Http.Extensions.RequestStopwatch",
-  "FGS.AspNetCore.Mvc.ModelBinding",
-  "FGS.AspNetCore.Mvc.ModelBinding.Validation",
-  "FGS.Autofac.AspNetCore.Mvc.Routing",
-  "FGS.Autofac.CompositionRoot",
-  "FGS.Autofac.CompositionRoot.Abstractions",
-  "FGS.Autofac.DynamicScoping",
-  "FGS.Autofac.DynamicScoping.Abstractions",
-  "FGS.Autofac.Interception.DynamicProxy",
-  "FGS.Autofac.Interceptors.FaultHandling",
-  "FGS.Autofac.Interceptors.Time",
-  "FGS.Autofac.Options",
-  "FGS.Autofac.Registration.Extensions",
-  "FGS.Collections.Extensions"
-  ]
-
 # This job is setup to only build on commits to `master`
 # _when files in the projects we're going to pack_ are changed. This is intended
 # to reduce churn in projects which depend on these packages since every build
@@ -79,10 +22,4 @@ pr: none
 
 stages:
 
-- stage: Deploy
-  displayName: Deploy
-  jobs:
-  - ${{ each packageProject in parameters.packageProjects  }}:
-    - template: ./BuildAndPushPackage.yml
-      parameters:
-        project: ${{ packageProject }}
+- template: ./BuildAndPushPackage.yml


### PR DESCRIPTION
For a pipeline `stage` to be a template, (and therefore have `parameters` than can be used with iterative insertion), it must be in a file separate from the root of a "pipeline" and referenced as a "template".

That is, our previous attempts to define `parameters` at the root of the pipeline YAML violates the schema because they are only valid for templates, and templates are only valid for `stage`s, `job`s, and `step`s.

For more information on the general pipeline schema, see: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#pipeline
For more information on the template syntax, see: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops