### PR TITLE
📦🐛 Fixes NuGet Package Push

### DIFF
--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -68,7 +68,7 @@ stages:
       steps:
 
       - task: DotNetCoreCLI@2
-        displayName: dotnet pack "src/${{ project.value }}/${{ project.value }}.csproj"
+        displayName: dotnet pack "${{ project.value }}"
         inputs:
           command: pack
           packagesToPack: "src/${{ project.value }}/${{ project.value }}.csproj"
@@ -76,9 +76,9 @@ stages:
           arguments: --configuration Release
 
       - task: NuGetCommand@2
-        displayName: nuget push "src/${{ project.value }}/${{ project.value }}.csproj"
+        displayName: nuget push "${{ project.value }}"
         inputs:
           command: push
-          packagesToPush: "src/${{ project.value }}/**/*.nupkg;!src/${{ project.value }}/**/*.symbols.nupkg"
+          packagesToPush: "**/*.nupkg;!**/*.symbols.nupkg"
           nuGetFeedType: external
           publishFeedCredentials: "NuGet foxguardsolutions Push All FGS.*"


### PR DESCRIPTION
When the NuGet package push was split to be per-project, the implementation incorrectly assumed that the output of the built packages would be located in the child folders of the respective projects. Instead, the `DotNetCoreCLI@2` task puts them (by default) in a parent folder of the working copy of the code. As such, this removes the path filtering that causes the NuGet package push to not find any packages.