### PR TITLE
📦🐛 Aligns Folders of `dotnet pack` & `nuget push`

### DIFF
--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -72,6 +72,7 @@ stages:
         inputs:
           command: pack
           packagesToPack: "src/${{ project.value }}/${{ project.value }}.csproj"
+          outputDir: "$(Build.ArtifactStagingDirectory)"
           versioningScheme: byBuildNumber
           arguments: --configuration Release
 
@@ -79,6 +80,6 @@ stages:
         displayName: nuget push "${{ project.value }}"
         inputs:
           command: push
-          packagesToPush: "**/*.nupkg;!**/*.symbols.nupkg"
+          packagesToPush: "$(Build.ArtifactStagingDirectory)*.nupkg;!$(Build.ArtifactStagingDirectory)/*.symbols.nupkg"
           nuGetFeedType: external
           publishFeedCredentials: "NuGet foxguardsolutions Push All FGS.*"


### PR DESCRIPTION
Detailed logs from our NuGet package publishing pipeline indicates that the path written to by `dotnet pack` is completely orthogonal to the one later read from by `nuget push`. This aligns them to be based around the same path.