### PR TITLE
📦🐛 Corrects Typo in `nuget push` Step

### DIFF
--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -80,6 +80,6 @@ stages:
         displayName: nuget push "${{ project.value }}"
         inputs:
           command: push
-          packagesToPush: "$(Build.ArtifactStagingDirectory)*.nupkg;!$(Build.ArtifactStagingDirectory)/*.symbols.nupkg"
+          packagesToPush: "$(Build.ArtifactStagingDirectory)/*.nupkg;!$(Build.ArtifactStagingDirectory)/*.symbols.nupkg"
           nuGetFeedType: external
           publishFeedCredentials: "NuGet foxguardsolutions Push All FGS.*"


### PR DESCRIPTION
`Build.ArtifactStagingDirectory` does _not_ include a trailing slash, so we must (always) append one when combining it with a search pattern.