### PR TITLE
✨ Adds "Hosting Middleware" Abstraction & Wiring Helper

### DIFF
--- a/FGS.Foundation.sln
+++ b/FGS.Foundation.sln
@@ -4,8 +4,16 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 16.0.29123.88
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2FC8DF88-182F-4A79-9185-F242A6C12701}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.targets = src\Directory.Build.targets
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{355D7A68-14B5-4489-B3D3-D1BCBE44B774}"
+	ProjectSection(SolutionItems) = preProject
+		test\Directory.Build.props = test\Directory.Build.props
+		test\Directory.Build.targets = test\Directory.Build.targets
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.AspNetCore.Hosting.Extensions.DependencyInjection.Autofac", "src\FGS.AspNetCore.Hosting.Extensions.DependencyInjection.Autofac\FGS.AspNetCore.Hosting.Extensions.DependencyInjection.Autofac.csproj", "{6D35876D-19F6-466F-A778-0D8483B452D7}"
 EndProject

--- a/FGS.Foundation.sln
+++ b/FGS.Foundation.sln
@@ -137,6 +137,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Primitives.Extensions.T
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Primitives.Time.Tests", "test\FGS.Primitives.Time.Tests\FGS.Primitives.Time.Tests.csproj", "{D639F8A5-8E01-4917-8DAC-646083FB65BE}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Extensions.Hosting.Middleware.Abstractions", "src\FGS.Extensions.Hosting.Middleware.Abstractions\FGS.Extensions.Hosting.Middleware.Abstractions.csproj", "{6E667FAD-B06B-4754-A511-0C66D4A6D39A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Extensions.Hosting.Middleware", "src\FGS.Extensions.Hosting.Middleware\FGS.Extensions.Hosting.Middleware.csproj", "{C3608BFF-4440-4671-8E7D-8144D4D62B51}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Extensions.Hosting.Middleware.Tests", "test\FGS.Extensions.Hosting.Middleware.Tests\FGS.Extensions.Hosting.Middleware.Tests.csproj", "{4CCE9B2B-7857-45FC-ACBD-76A49ACDDA5B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -387,6 +393,18 @@ Global
 		{D639F8A5-8E01-4917-8DAC-646083FB65BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D639F8A5-8E01-4917-8DAC-646083FB65BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D639F8A5-8E01-4917-8DAC-646083FB65BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E667FAD-B06B-4754-A511-0C66D4A6D39A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E667FAD-B06B-4754-A511-0C66D4A6D39A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E667FAD-B06B-4754-A511-0C66D4A6D39A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E667FAD-B06B-4754-A511-0C66D4A6D39A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3608BFF-4440-4671-8E7D-8144D4D62B51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3608BFF-4440-4671-8E7D-8144D4D62B51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3608BFF-4440-4671-8E7D-8144D4D62B51}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3608BFF-4440-4671-8E7D-8144D4D62B51}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CCE9B2B-7857-45FC-ACBD-76A49ACDDA5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CCE9B2B-7857-45FC-ACBD-76A49ACDDA5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CCE9B2B-7857-45FC-ACBD-76A49ACDDA5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CCE9B2B-7857-45FC-ACBD-76A49ACDDA5B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -453,6 +471,9 @@ Global
 		{CCA4BA06-44CF-4B65-89C0-C56C3723CA07} = {355D7A68-14B5-4489-B3D3-D1BCBE44B774}
 		{DF4B5F79-591D-4D31-B3EC-55AC3E7B72AE} = {355D7A68-14B5-4489-B3D3-D1BCBE44B774}
 		{D639F8A5-8E01-4917-8DAC-646083FB65BE} = {355D7A68-14B5-4489-B3D3-D1BCBE44B774}
+		{6E667FAD-B06B-4754-A511-0C66D4A6D39A} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{C3608BFF-4440-4671-8E7D-8144D4D62B51} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{4CCE9B2B-7857-45FC-ACBD-76A49ACDDA5B} = {355D7A68-14B5-4489-B3D3-D1BCBE44B774}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9BE7FA6F-2D4E-4B5B-97B7-7D2DE8E3DB1E}

--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -80,6 +80,6 @@ stages:
         displayName: nuget push "${{ project.value }}"
         inputs:
           command: push
-          packagesToPush: "$(Build.ArtifactStagingDirectory)/*.nupkg;!$(Build.ArtifactStagingDirectory)/*.symbols.nupkg"
+          packagesToPush: "$(Build.ArtifactStagingDirectory)/*.nupkg;$(Build.ArtifactStagingDirectory)/*.snupkg"
           nuGetFeedType: external
           publishFeedCredentials: "NuGet foxguardsolutions Push All FGS.*"

--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -53,6 +53,8 @@ parameters:
     50: FGS.Autofac.Options
     51: FGS.Autofac.Registration.Extensions
     52: FGS.Collections.Extensions
+    53: FGS.Extensions.Hosting.Middleware.Abstractions
+    54: FGS.Extensions.Hosting.Middleware
 
 stages:
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <Authors>FoxGuard Solutions</Authors>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,5 +4,7 @@
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IncludeSymbols>true</IncludeSymbols>	
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>	
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,6 +4,7 @@
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>	
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>	
   </PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01">
+        <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/src/FGS.Extensions.Hosting.Middleware.Abstractions/FGS.Extensions.Hosting.Middleware.Abstractions.csproj
+++ b/src/FGS.Extensions.Hosting.Middleware.Abstractions/FGS.Extensions.Hosting.Middleware.Abstractions.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+
+    <Description>
+      Provides an abstraction of "hosting middleware" that can be added to the application's web hosting pipeline as a means to asynchronously intercept startup and graceful shutdowns.
+
+      Part of an alternative to `IStartupFilter` that is asynchronous.
+    </Description>
+    <PackageTags>aspnet;aspnetcore;hosting;startup;middleware;IStartupFilter</PackageTags>
+  </PropertyGroup>
+
+</Project>

--- a/src/FGS.Extensions.Hosting.Middleware.Abstractions/IHostingMiddleware.cs
+++ b/src/FGS.Extensions.Hosting.Middleware.Abstractions/IHostingMiddleware.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FGS.Extensions.Hosting.Middleware.Abstractions
+{
+    /// <summary>
+    /// Defines middleware that can be added to the application's web hosting pipeline as a means to asynchronously intercept
+    /// startup and graceful shutdowns.
+    /// </summary>
+    public interface IHostingMiddleware
+    {
+        /// <summary>
+        /// Represents functionality that runs before and/or after the underlying web host starts listening on the configured address.
+        /// </summary>
+        /// <param name="next">The delegate representing the remaining middleware in the web hosting pipeline.</param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+        Task StartAsync(Func<Task> next, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Represents functionality that runs before and/or after attempting to gracefully stop the underlying web host.
+        /// </summary>
+        /// <param name="next">The delegate representing the remaining middleware in the web hosting pipeline.</param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+        Task StopAsync(Func<Task> next, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/FGS.Extensions.Hosting.Middleware/DecoratorApplyingHostBuilderDecorator.cs
+++ b/src/FGS.Extensions.Hosting.Middleware/DecoratorApplyingHostBuilderDecorator.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace FGS.Extensions.Hosting.Middleware
+{
+    /// <summary>
+    /// An implementation of <see cref="IHostBuilder"/> that wraps an inner implementation with the added behavior of intercepting calls
+    /// to <see cref="IHostBuilder.Build"/> and wrapping the result with decorator before returning it.
+    /// </summary>
+    internal sealed class DecoratorApplyingHostBuilderDecorator : IHostBuilder
+    {
+        private readonly IHostBuilder _decorated;
+        private readonly Func<IHost, IHost> _decorateBuildResult;
+
+        internal DecoratorApplyingHostBuilderDecorator(IHostBuilder decorated, Func<IHost, IHost> decorateBuildResult)
+        {
+            _decorated = decorated;
+            _decorateBuildResult = decorateBuildResult;
+        }
+
+        IHostBuilder IHostBuilder.ConfigureHostConfiguration(Action<IConfigurationBuilder> configureDelegate) =>
+            _decorated.ConfigureHostConfiguration(configureDelegate);
+
+        IHostBuilder IHostBuilder.ConfigureAppConfiguration(Action<HostBuilderContext, IConfigurationBuilder> configureDelegate) =>
+            _decorated.ConfigureAppConfiguration(configureDelegate);
+
+        IHostBuilder IHostBuilder.ConfigureServices(Action<HostBuilderContext, IServiceCollection> configureDelegate) =>
+            _decorated.ConfigureServices(configureDelegate);
+
+        IHostBuilder IHostBuilder.UseServiceProviderFactory<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory) =>
+            _decorated.UseServiceProviderFactory(factory);
+
+        IHostBuilder IHostBuilder.UseServiceProviderFactory<TContainerBuilder>(Func<HostBuilderContext, IServiceProviderFactory<TContainerBuilder>> factory) =>
+            _decorated.UseServiceProviderFactory(factory);
+
+        IHostBuilder IHostBuilder.ConfigureContainer<TContainerBuilder>(Action<HostBuilderContext, TContainerBuilder> configureDelegate) =>
+            _decorated.ConfigureContainer(configureDelegate);
+
+        IHost IHostBuilder.Build() =>
+            _decorateBuildResult(_decorated.Build());
+
+        IDictionary<object, object> IHostBuilder.Properties => _decorated.Properties;
+    }
+}

--- a/src/FGS.Extensions.Hosting.Middleware/FGS.Extensions.Hosting.Middleware.csproj
+++ b/src/FGS.Extensions.Hosting.Middleware/FGS.Extensions.Hosting.Middleware.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+
+    <Description>
+      Provides functionality to wire up "hosting middleware" that can be added to the application's web hosting pipeline as a means to asynchronously intercept startup and graceful shutdowns.
+
+      An alternative to `IStartupFilter` that is asynchronous.
+    </Description>
+    <PackageTags>aspnet;aspnetcore;hosting;startup;middleware;IStartupFilter</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FGS.Extensions.Hosting.Middleware.Abstractions\FGS.Extensions.Hosting.Middleware.Abstractions.csproj" />
+  </ItemGroup>
+
+
+</Project>

--- a/src/FGS.Extensions.Hosting.Middleware/HostBuilderExtensions.cs
+++ b/src/FGS.Extensions.Hosting.Middleware/HostBuilderExtensions.cs
@@ -1,0 +1,49 @@
+using System;
+
+using FGS.Extensions.Hosting.Middleware.Abstractions;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace FGS.Extensions.Hosting.Middleware
+{
+    /// <summary>
+    /// Extends <see cref="IHostBuilder"/> with functionality for configuring the usage of instances of <see cref="IHostingMiddleware"/> to intercept calls
+    /// to the later-built <see cref="IHost"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// public static IWebHostBuilder CreateWebHostBuilder(string[] args) =&gt;
+    ///     WebHost.CreateDefaultBuilder(args)
+    ///         .UseStartup&lt;Startup&gt;()
+    ///         .UseHostingMiddleware&lt;MyHostingMiddleware&gt;();
+    /// </code>
+    /// </example>
+    public static class HostBuilderExtensions
+    {
+        /// <summary>
+        /// Adds hosting middleware functionality to the web host startup &amp; graceful shutdown process, relying on an instance of
+        /// <typeparamref name="THostingMiddleware"/> to provide interceptor behavior.
+        /// </summary>
+        /// <param name="hostBuilder">An instance of the program initialization abstraction that is to be modified.</param>
+        /// <param name="hostingMiddlewareFactory">Optionally creates or retrieves an instance of <typeparamref name="THostingMiddleware"/> to use.
+        /// If not specified, an instance will be requested from the <see cref="IServiceProvider"/>.</param>
+        /// <typeparam name="THostingMiddleware">The type of <see cref="IHostingMiddleware"/> that will be used to intercept web host startup &amp; graceful shutdown.</typeparam>
+        /// <returns>A program initialization abstraction that has been augmented to apply a <see cref="IHostingMiddleware"/> to the eventually-created <see cref="IHost"/>.</returns>
+        /// <remarks>Multiple calls to this will apply multiple layers of the hosting middleware stack, each one specific to that invocation and desired middleware.</remarks>
+        public static IHostBuilder UseHostingMiddleware<THostingMiddleware>(this IHostBuilder hostBuilder, Func<IServiceProvider, THostingMiddleware> hostingMiddlewareFactory = null)
+            where THostingMiddleware : IHostingMiddleware
+        {
+            hostingMiddlewareFactory ??= (sp) => sp.GetRequiredService<THostingMiddleware>();
+
+            IHost CreateHostDecorator(IHost decorated)
+            {
+                var hostingMiddlewareDecoraptor = new ServiceScopeResolvedHostingMiddlewareDecoraptor<THostingMiddleware>(() => decorated.Services.CreateScope(), hostingMiddlewareFactory);
+
+                return new MiddlewareApplyingHostDecorator(decorated, hostingMiddlewareDecoraptor);
+            }
+
+            return new DecoratorApplyingHostBuilderDecorator(hostBuilder, CreateHostDecorator);
+        }
+    }
+}

--- a/src/FGS.Extensions.Hosting.Middleware/MiddlewareApplyingHostDecorator.cs
+++ b/src/FGS.Extensions.Hosting.Middleware/MiddlewareApplyingHostDecorator.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FGS.Extensions.Hosting.Middleware.Abstractions;
+
+using Microsoft.Extensions.Hosting;
+
+namespace FGS.Extensions.Hosting.Middleware
+{
+    /// <summary>
+    /// An implementation of <see cref="IHost"/> that decorates an underlying instance with interceptor behavior represented
+    /// by a given instance of <see cref="IHostingMiddleware"/>.
+    /// </summary>
+    internal sealed class MiddlewareApplyingHostDecorator : IHost
+    {
+        private readonly IHost _decorated;
+        private readonly IHostingMiddleware _hostingMiddleware;
+
+        internal MiddlewareApplyingHostDecorator(IHost decorated, IHostingMiddleware hostingMiddleware)
+        {
+            _decorated = decorated;
+            _hostingMiddleware = hostingMiddleware;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+        }
+
+        Task IHost.StartAsync(CancellationToken cancellationToken) =>
+            _hostingMiddleware.StartAsync(() => _decorated.StartAsync(cancellationToken), cancellationToken);
+
+        Task IHost.StopAsync(CancellationToken cancellationToken) =>
+            _hostingMiddleware.StopAsync(() => _decorated.StopAsync(cancellationToken), cancellationToken);
+
+        IServiceProvider IHost.Services => _decorated.Services;
+    }
+}

--- a/src/FGS.Extensions.Hosting.Middleware/ServiceScopeResolvedHostingMiddlewareDecoraptor.cs
+++ b/src/FGS.Extensions.Hosting.Middleware/ServiceScopeResolvedHostingMiddlewareDecoraptor.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FGS.Extensions.Hosting.Middleware.Abstractions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FGS.Extensions.Hosting.Middleware
+{
+    /// <summary>
+    /// An implementation of <see cref="IHostingMiddleware"/> whose purpose is to defer implementation to a transiently resolved
+    /// instance of <typeparamref name="THostingMiddleware"/>, which is acquired via an <see cref="IServiceScope"/>.
+    /// </summary>
+    /// <typeparam name="THostingMiddleware">The type of <see cref="IHostingMiddleware"/> that will be resolved and used as the underlying implementation.</typeparam>
+    internal sealed class ServiceScopeResolvedHostingMiddlewareDecoraptor<THostingMiddleware> : IHostingMiddleware
+        where THostingMiddleware : IHostingMiddleware
+    {
+        private readonly Func<IServiceScope> _serviceScopeFactory;
+        private readonly Func<IServiceProvider, THostingMiddleware> _hostingMiddlewareFactory;
+
+        internal ServiceScopeResolvedHostingMiddlewareDecoraptor(Func<IServiceScope> serviceScopeFactory, Func<IServiceProvider, THostingMiddleware> hostingMiddlewareFactory)
+        {
+            _serviceScopeFactory = serviceScopeFactory;
+            _hostingMiddlewareFactory = hostingMiddlewareFactory;
+        }
+
+        Task IHostingMiddleware.StartAsync(Func<Task> next, CancellationToken cancellationToken)
+        {
+            using var serviceScope = _serviceScopeFactory();
+            var middleware = _hostingMiddlewareFactory(serviceScope.ServiceProvider);
+            return middleware.StartAsync(next, cancellationToken);
+        }
+
+        Task IHostingMiddleware.StopAsync(Func<Task> next, CancellationToken cancellationToken)
+        {
+            using var serviceScope = _serviceScopeFactory();
+            var middleware = _hostingMiddlewareFactory(serviceScope.ServiceProvider);
+            return middleware.StopAsync(next, cancellationToken);
+        }
+    }
+}

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+</Project>

--- a/test/FGS.AspNetCore.Hosting.Extensions.Logging.Serilog.Tests/FGS.AspNetCore.Hosting.Extensions.Logging.Serilog.Tests.csproj
+++ b/test/FGS.AspNetCore.Hosting.Extensions.Logging.Serilog.Tests/FGS.AspNetCore.Hosting.Extensions.Logging.Serilog.Tests.csproj
@@ -1,11 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <AssemblyName>FGS.AspNetCore.Hosting.Extensions.Logging.Serilog.Tests</AssemblyName>
-    <RootNamespace>FGS.AspNetCore.Hosting.Extensions.Logging.Serilog.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/FGS.Autofac.Interception.DynamicProxy.Tests/FGS.Autofac.Interception.DynamicProxy.Tests.csproj
+++ b/test/FGS.Autofac.Interception.DynamicProxy.Tests/FGS.Autofac.Interception.DynamicProxy.Tests.csproj
@@ -1,23 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
     <PackageReference Include="Castle.Core" Version="4.4.0" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/FGS.Autofac.Interceptors.FaultHandling.Tests/FGS.Autofac.Interceptors.FaultHandling.Tests.csproj
+++ b/test/FGS.Autofac.Interceptors.FaultHandling.Tests/FGS.Autofac.Interceptors.FaultHandling.Tests.csproj
@@ -7,15 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="System.Configuration.Abstractions" Version="2.0.2.45" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/FGS.ComponentModel.DataAnnotations.Tests/FGS.ComponentModel.DataAnnotations.Tests.csproj
+++ b/test/FGS.ComponentModel.DataAnnotations.Tests/FGS.ComponentModel.DataAnnotations.Tests.csproj
@@ -1,21 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\FGS.ComponentModel.DataAnnotations\FGS.ComponentModel.DataAnnotations.csproj" />

--- a/test/FGS.Extensions.Hosting.Middleware.Tests/FGS.Extensions.Hosting.Middleware.Tests.csproj
+++ b/test/FGS.Extensions.Hosting.Middleware.Tests/FGS.Extensions.Hosting.Middleware.Tests.csproj
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FGS.Extensions.Hosting.Middleware.Abstractions\FGS.Extensions.Hosting.Middleware.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\FGS.Extensions.Hosting.Middleware\FGS.Extensions.Hosting.Middleware.csproj" />
+    <ProjectReference Include="..\..\src\FGS.Tests.Support\FGS.Tests.Support.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/FGS.Extensions.Hosting.Middleware.Tests/HostBuilderExtensionsTests.cs
+++ b/test/FGS.Extensions.Hosting.Middleware.Tests/HostBuilderExtensionsTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FGS.Extensions.Hosting.Middleware.Tests.Mocks;
+using FGS.Tests.Support.TestCategories;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using NUnit.Framework;
+
+namespace FGS.Extensions.Hosting.Middleware.Tests
+{
+    [Unit]
+    [TestFixture]
+    public class HostBuilderExtensionsTests
+    {
+        private IHostBuilder _hostBuilder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            HostSpy.Reset();
+            _hostBuilder = CreateHostBuilder();
+        }
+
+        [Test]
+        public async Task UseHostingMiddleware_GivenHostCallingHostingMiddleware_BuildAndRunAsync_OnStart_CallsHostStart()
+        {
+            Given_HostCallingHostingMiddleware();
+
+            await BuildAndRunAsync();
+
+            Verify_HostStart_Called();
+        }
+
+        [Test]
+        public async Task UseHostingMiddleware_GivenHostCallingHostingMiddleware_BuildAndRunAsync_OnStop_CallsHostStop()
+        {
+            Given_HostCallingHostingMiddleware();
+
+            await BuildAndRunAsync();
+
+            Verify_HostStop_Called();
+        }
+
+        [Test]
+        public async Task UseHostingMiddleware_GivenHostSkippingHostingMiddleware_BuildAndRunAsync_OnStart_DoesNotCallHostStart()
+        {
+            Given_HostSkippingHostingMiddleware();
+
+            await BuildAndRunAsync();
+
+            Verify_HostStart_NotCalled();
+        }
+
+        [Test]
+        public async Task UseHostingMiddleware_GivenHostSkippingHostingMiddleware_BuildAndRunAsync_OnStop_DoesNotCallHostStop()
+        {
+            Given_HostSkippingHostingMiddleware();
+
+            await BuildAndRunAsync();
+
+            Verify_HostStop_NotCalled();
+        }
+
+        private static IHostBuilder CreateHostBuilder()
+        {
+            IHostBuilder result = new HostBuilder();
+            return result.ConfigureServices(
+                sc =>
+                {
+                    sc.AddSingleton<IHost, HostSpy>();
+                    sc.AddSingleton(CreateFakeServiceScopeFactory);
+                });
+        }
+
+        private static IServiceScopeFactory CreateFakeServiceScopeFactory(IServiceProvider serviceProvider)
+        {
+            IServiceScope CreateFakeServiceScope()
+            {
+                var mockServiceScope = new Mock<IServiceScope>();
+                mockServiceScope.Setup(ss => ss.ServiceProvider).Returns(serviceProvider);
+                return mockServiceScope.Object;
+            }
+
+            var mockServiceScopeFactory = new Mock<IServiceScopeFactory>();
+            mockServiceScopeFactory.Setup(ssf => ssf.CreateScope()).Returns(CreateFakeServiceScope);
+            return mockServiceScopeFactory.Object;
+        }
+
+        private void Verify_HostStart_Called()
+        {
+            HostSpy.StartAsyncCallCount.Should().Be(1);
+        }
+
+        private void Verify_HostStop_Called()
+        {
+            HostSpy.StopAsyncCallCount.Should().Be(1);
+        }
+
+        private void Verify_HostStart_NotCalled()
+        {
+            HostSpy.StartAsyncCallCount.Should().Be(0);
+        }
+
+        private void Verify_HostStop_NotCalled()
+        {
+            HostSpy.StopAsyncCallCount.Should().Be(0);
+        }
+
+        private void Given_HostCallingHostingMiddleware()
+        {
+            _hostBuilder.ConfigureServices(sc => sc.AddScoped<HostCallingHostingMiddleware>());
+            _hostBuilder = _hostBuilder.UseHostingMiddleware(sp => sp.GetRequiredService<HostCallingHostingMiddleware>());
+        }
+
+        private void Given_HostSkippingHostingMiddleware()
+        {
+            _hostBuilder.ConfigureServices(sc => sc.AddScoped<HostSkippingHostingMiddleware>());
+            _hostBuilder = _hostBuilder.UseHostingMiddleware(sp => sp.GetRequiredService<HostSkippingHostingMiddleware>());
+        }
+
+        private Task BuildAndRunAsync()
+        {
+            var immediatelyCancelToken = new CancellationToken(true);
+            return _hostBuilder.Build().RunAsync(immediatelyCancelToken);
+        }
+    }
+}

--- a/test/FGS.Extensions.Hosting.Middleware.Tests/Mocks/HostCallingHostingMiddleware.cs
+++ b/test/FGS.Extensions.Hosting.Middleware.Tests/Mocks/HostCallingHostingMiddleware.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FGS.Extensions.Hosting.Middleware.Abstractions;
+
+namespace FGS.Extensions.Hosting.Middleware.Tests.Mocks
+{
+    public class HostCallingHostingMiddleware : IHostingMiddleware
+    {
+        public Task StartAsync(Func<Task> next, CancellationToken cancellationToken = default) =>
+            next();
+
+        public Task StopAsync(Func<Task> next, CancellationToken cancellationToken = default) =>
+            next();
+    }
+}

--- a/test/FGS.Extensions.Hosting.Middleware.Tests/Mocks/HostSkippingHostingMiddleware.cs
+++ b/test/FGS.Extensions.Hosting.Middleware.Tests/Mocks/HostSkippingHostingMiddleware.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FGS.Extensions.Hosting.Middleware.Abstractions;
+
+namespace FGS.Extensions.Hosting.Middleware.Tests.Mocks
+{
+    public class HostSkippingHostingMiddleware : IHostingMiddleware
+    {
+        public Task StartAsync(Func<Task> next, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task StopAsync(Func<Task> next, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+    }
+}

--- a/test/FGS.Extensions.Hosting.Middleware.Tests/Mocks/HostSpy.cs
+++ b/test/FGS.Extensions.Hosting.Middleware.Tests/Mocks/HostSpy.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace FGS.Extensions.Hosting.Middleware.Tests.Mocks
+{
+    public sealed class HostSpy : IHost
+    {
+        public static int StartAsyncCallCount = 0;
+        public static int StopAsyncCallCount = 0;
+
+        public HostSpy(IServiceProvider services)
+        {
+            Services = services;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            StartAsyncCallCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            StopAsyncCallCount++;
+            return Task.CompletedTask;
+        }
+
+        public IServiceProvider Services { get; }
+
+        public static void Reset()
+        {
+            StartAsyncCallCount = 0;
+            StopAsyncCallCount = 0;
+        }
+    }
+}

--- a/test/FGS.Extensions.Logging.Serilog.Tests/FGS.Extensions.Logging.Serilog.Tests.csproj
+++ b/test/FGS.Extensions.Logging.Serilog.Tests/FGS.Extensions.Logging.Serilog.Tests.csproj
@@ -1,11 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <AssemblyName>FGS.Extensions.Logging.Serilog.Tests</AssemblyName>
-    <RootNamespace>FGS.Extensions.Logging.Serilog.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/FGS.FaultHandling.Polly.Tests/FGS.FaultHandling.Polly.Tests.csproj
+++ b/test/FGS.FaultHandling.Polly.Tests/FGS.FaultHandling.Polly.Tests.csproj
@@ -6,20 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.9.4" />
-    <PackageReference Include="Castle.Core" Version="4.4.0" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="System.Configuration.Abstractions" Version="2.0.2.45" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\FGS.FaultHandling.Polly\FGS.FaultHandling.Polly.csproj" />
     <ProjectReference Include="..\..\src\FGS.Tests.Support.AutoFixture.Mocking.Options\FGS.Tests.Support.AutoFixture.Mocking.Options.csproj" />
     <ProjectReference Include="..\..\src\FGS.Tests.Support\FGS.Tests.Support.csproj" />

--- a/test/FGS.FaultHandling.Primitives.Tests/FGS.FaultHandling.Primitives.Tests.csproj
+++ b/test/FGS.FaultHandling.Primitives.Tests/FGS.FaultHandling.Primitives.Tests.csproj
@@ -6,20 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.9.4" />
-    <PackageReference Include="Castle.Core" Version="4.4.0" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="System.Configuration.Abstractions" Version="2.0.2.45" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\FGS.FaultHandling.Primitives\FGS.FaultHandling.Primitives.csproj" />
     <ProjectReference Include="..\..\src\FGS.Tests.Support.AutoFixture.Mocking\FGS.Tests.Support.AutoFixture.Mocking.csproj" />
     <ProjectReference Include="..\..\src\FGS.Tests.Support\FGS.Tests.Support.csproj" />

--- a/test/FGS.Primitives.Extensions.Tests/FGS.Primitives.Extensions.Tests.csproj
+++ b/test/FGS.Primitives.Extensions.Tests/FGS.Primitives.Extensions.Tests.csproj
@@ -1,20 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\FGS.Primitives.Extensions\FGS.Primitives.Extensions.csproj" />

--- a/test/FGS.Primitives.Time.Tests/FGS.Primitives.Time.Tests.csproj
+++ b/test/FGS.Primitives.Time.Tests/FGS.Primitives.Time.Tests.csproj
@@ -3,17 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\FGS.Primitives.Time.Abstractions\FGS.Primitives.Time.Abstractions.csproj" />


### PR DESCRIPTION
Allows consumers to run async tasks on startup in ASP.NET Core.
Designed around an injected abstraction of `IHostingMiddleware` so that implementations are individually testable and compatible with composition techniques.

Specifically designed as an alternative to the undesirable approaches seen here: https://andrewlock.net/running-async-tasks-on-app-startup-in-asp-net-core-part-1/

Also makes some small changes to project files in order to assist in library maintainability and usability.