### PR TITLE
🚀🐛 Fixes `snupkg` Push

### DIFF
--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -69,6 +69,13 @@ stages:
 
       steps:
 
+      - task: NuGetToolInstaller@0
+        inputs:
+          versionSpec: '>=4.9.1'
+
+      - pwsh: |
+            nuget sources Update -Name nuget.org -Source https://api.nuget.org/v3/index.json
+
       - task: DotNetCoreCLI@2
         displayName: dotnet pack "${{ project.value }}"
         inputs:


### PR DESCRIPTION
The new symbol package format requires that we use a recent version of the `nuget` executable when doing package pushes, and that we use the v3 version of the NuGet.org API url. This ensures that both are the case, so that our package publishes will succeed again.