### PR TITLE
🚀🐛 Removes Redundant `snupkg` Push

### DIFF
--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -89,6 +89,6 @@ stages:
         displayName: nuget push "${{ project.value }}"
         inputs:
           command: push
-          packagesToPush: "$(Build.ArtifactStagingDirectory)/*.nupkg;$(Build.ArtifactStagingDirectory)/*.snupkg"
+          packagesToPush: "$(Build.ArtifactStagingDirectory)/*.nupkg"
           nuGetFeedType: external
           publishFeedCredentials: "NuGet foxguardsolutions Push All FGS.*"


### PR DESCRIPTION
NuGet will push `snupkg`s when the accompanying `nupkg` is pushed, which makes this extra glob cause redundant pushes which result in errors from the NuGet API.