### PR TITLE
🚀🐛 Adds Missing Package Publishes

### DIFF
--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -55,6 +55,8 @@ parameters:
     52: FGS.Collections.Extensions
     53: FGS.Extensions.Hosting.Middleware.Abstractions
     54: FGS.Extensions.Hosting.Middleware
+    55: FGS.Extensions.Hosting.DependencyInjection.Autofac
+    56: FGS.Extensions.Hosting.Logging.Serilog
 
 stages:
 


### PR DESCRIPTION
These packages were "added" in a recent change, but we neglected to register them into the publish task. This corrects such.