### PR TITLE
✨ Enriches Queries w/ `.Map`, `.Paginate`, & `.Materialize`

### DIFF
--- a/FGS.Foundation.sln
+++ b/FGS.Foundation.sln
@@ -173,9 +173,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.Paginat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.Pagination.EntityFrameworkCore", "src\FGS.Linq.Extensions.Pagination.EntityFrameworkCore\FGS.Linq.Extensions.Pagination.EntityFrameworkCore.csproj", "{5B6E00E9-4217-45FB-93DA-0E822DC6B42D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Collections.Extensions.OneOf.Units", "src\FGS.Collections.Extensions.OneOf.Units\FGS.Collections.Extensions.OneOf.Units.csproj", "{431C9136-225F-43FF-B11B-B5A597913166}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FGS.Linq.Extensions.OneOf.EntityFramework.Shared", "src\FGS.Linq.Extensions.OneOf.EntityFramework.Shared\FGS.Linq.Extensions.OneOf.EntityFramework.Shared.shproj", "{8A11571F-0DE7-4E1F-8C1D-6A441F3EAA85}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.OneOf.EntityFramework6", "src\FGS.Linq.Extensions.OneOf.EntityFramework6\FGS.Linq.Extensions.OneOf.EntityFramework6.csproj", "{037E878C-996E-4922-AC99-38DB0644CB79}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.OneOf.EntityFrameworkCore", "src\FGS.Linq.Extensions.OneOf.EntityFrameworkCore\FGS.Linq.Extensions.OneOf.EntityFrameworkCore.csproj", "{19AC1E1D-73F5-4F74-8DC9-14E327933B3E}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\FGS.Linq.Extensions.AutoMapper.Shared\FGS.Linq.Extensions.AutoMapper.Shared.projitems*{293e1465-e2e0-40c1-a28d-1bbd23961b55}*SharedItemsImports = 13
+		src\FGS.Linq.Extensions.OneOf.EntityFramework.Shared\FGS.Linq.Extensions.OneOf.EntityFramework.Shared.projitems*{8a11571f-0de7-4e1f-8c1d-6a441f3eaa85}*SharedItemsImports = 13
 		src\FGS.Linq.Extensions.Pagination.EntityFramework.Shared\FGS.Linq.Extensions.Pagination.EntityFramework.Shared.projitems*{96015fe6-1b5e-48f4-bcb3-464366c098f2}*SharedItemsImports = 13
 		src\FGS.Linq.Extensions.EntityFramework.Shared\FGS.Linq.Extensions.EntityFramework.Shared.projitems*{a3e025be-c165-4bc4-bf83-a9bf5dc512e2}*SharedItemsImports = 13
 	EndGlobalSection
@@ -488,6 +497,18 @@ Global
 		{5B6E00E9-4217-45FB-93DA-0E822DC6B42D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5B6E00E9-4217-45FB-93DA-0E822DC6B42D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5B6E00E9-4217-45FB-93DA-0E822DC6B42D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{431C9136-225F-43FF-B11B-B5A597913166}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{431C9136-225F-43FF-B11B-B5A597913166}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{431C9136-225F-43FF-B11B-B5A597913166}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{431C9136-225F-43FF-B11B-B5A597913166}.Release|Any CPU.Build.0 = Release|Any CPU
+		{037E878C-996E-4922-AC99-38DB0644CB79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{037E878C-996E-4922-AC99-38DB0644CB79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{037E878C-996E-4922-AC99-38DB0644CB79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{037E878C-996E-4922-AC99-38DB0644CB79}.Release|Any CPU.Build.0 = Release|Any CPU
+		{19AC1E1D-73F5-4F74-8DC9-14E327933B3E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19AC1E1D-73F5-4F74-8DC9-14E327933B3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19AC1E1D-73F5-4F74-8DC9-14E327933B3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19AC1E1D-73F5-4F74-8DC9-14E327933B3E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -572,6 +593,10 @@ Global
 		{96015FE6-1B5E-48F4-BCB3-464366C098F2} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 		{8A64A5C6-2B3C-4BB2-B9FC-7C30B3F2B3E2} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 		{5B6E00E9-4217-45FB-93DA-0E822DC6B42D} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{431C9136-225F-43FF-B11B-B5A597913166} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{8A11571F-0DE7-4E1F-8C1D-6A441F3EAA85} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{037E878C-996E-4922-AC99-38DB0644CB79} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{19AC1E1D-73F5-4F74-8DC9-14E327933B3E} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9BE7FA6F-2D4E-4B5B-97B7-7D2DE8E3DB1E}

--- a/FGS.Foundation.sln
+++ b/FGS.Foundation.sln
@@ -145,13 +145,22 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Extensions.Hosting.Depe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Extensions.Hosting.Logging.Serilog", "src\FGS.Extensions.Hosting.Logging.Serilog\FGS.Extensions.Hosting.Logging.Serilog.csproj", "{F59A1DDB-EFFB-4EBA-AE45-3DA59B25FA0D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Tests.Support.Extensions.Hosting.Middleware.Mocking", "src\FGS.Tests.Support.Extensions.Hosting.Middleware.Mocking\FGS.Tests.Support.Extensions.Hosting.Middleware.Mocking.csproj", "{BF244A7D-7728-4F46-948D-877B18159A3D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Tests.Support.Extensions.Hosting.Middleware.Mocking", "src\FGS.Tests.Support.Extensions.Hosting.Middleware.Mocking\FGS.Tests.Support.Extensions.Hosting.Middleware.Mocking.csproj", "{BF244A7D-7728-4F46-948D-877B18159A3D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Extensions.Hosting.Middleware.DelayedStart", "src\FGS.Extensions.Hosting.Middleware.DelayedStart\FGS.Extensions.Hosting.Middleware.DelayedStart.csproj", "{05D9D419-6E36-4AB8-8E7E-AEB3D635C603}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Extensions.Hosting.Middleware.DelayedStart", "src\FGS.Extensions.Hosting.Middleware.DelayedStart\FGS.Extensions.Hosting.Middleware.DelayedStart.csproj", "{05D9D419-6E36-4AB8-8E7E-AEB3D635C603}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Extensions.Hosting.Middleware.DelayedStart.Tests", "test\FGS.Extensions.Hosting.Middleware.DelayedStart.Tests\FGS.Extensions.Hosting.Middleware.DelayedStart.Tests.csproj", "{D638BF49-5051-4FD8-9555-6D51106EC0E6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Extensions.Hosting.Middleware.DelayedStart.Tests", "test\FGS.Extensions.Hosting.Middleware.DelayedStart.Tests\FGS.Extensions.Hosting.Middleware.DelayedStart.Tests.csproj", "{D638BF49-5051-4FD8-9555-6D51106EC0E6}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FGS.Linq.Extensions.AutoMapper.Shared", "src\FGS.Linq.Extensions.AutoMapper.Shared\FGS.Linq.Extensions.AutoMapper.Shared.shproj", "{293E1465-E2E0-40C1-A28D-1BBD23961B55}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.AutoMapper7", "src\FGS.Linq.Extensions.AutoMapper7\FGS.Linq.Extensions.AutoMapper7.csproj", "{4FF4041C-1809-4800-A378-A80560A05D03}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Linq.Extensions.AutoMapper", "src\FGS.Linq.Extensions.AutoMapper\FGS.Linq.Extensions.AutoMapper.csproj", "{32407A8B-39E5-43C2-B63A-F490D2578272}"
 EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\FGS.Linq.Extensions.AutoMapper.Shared\FGS.Linq.Extensions.AutoMapper.Shared.projitems*{293e1465-e2e0-40c1-a28d-1bbd23961b55}*SharedItemsImports = 13
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -429,6 +438,14 @@ Global
 		{D638BF49-5051-4FD8-9555-6D51106EC0E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D638BF49-5051-4FD8-9555-6D51106EC0E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D638BF49-5051-4FD8-9555-6D51106EC0E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FF4041C-1809-4800-A378-A80560A05D03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FF4041C-1809-4800-A378-A80560A05D03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FF4041C-1809-4800-A378-A80560A05D03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FF4041C-1809-4800-A378-A80560A05D03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32407A8B-39E5-43C2-B63A-F490D2578272}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32407A8B-39E5-43C2-B63A-F490D2578272}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32407A8B-39E5-43C2-B63A-F490D2578272}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32407A8B-39E5-43C2-B63A-F490D2578272}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -502,6 +519,9 @@ Global
 		{BF244A7D-7728-4F46-948D-877B18159A3D} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 		{05D9D419-6E36-4AB8-8E7E-AEB3D635C603} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 		{D638BF49-5051-4FD8-9555-6D51106EC0E6} = {355D7A68-14B5-4489-B3D3-D1BCBE44B774}
+		{293E1465-E2E0-40C1-A28D-1BBD23961B55} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{4FF4041C-1809-4800-A378-A80560A05D03} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{32407A8B-39E5-43C2-B63A-F490D2578272} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9BE7FA6F-2D4E-4B5B-97B7-7D2DE8E3DB1E}

--- a/FGS.Foundation.sln
+++ b/FGS.Foundation.sln
@@ -161,9 +161,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.Paginat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.Pagination", "src\FGS.Linq.Extensions.Pagination\FGS.Linq.Extensions.Pagination.csproj", "{2483C4E7-E6CB-4E6C-9262-905F854DD803}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FGS.Linq.Extensions.EntityFramework.Shared", "src\FGS.Linq.Extensions.EntityFramework.Shared\FGS.Linq.Extensions.EntityFramework.Shared.shproj", "{A3E025BE-C165-4BC4-BF83-A9BF5DC512E2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.EntityFramework6", "src\FGS.Linq.Extensions.EntityFramework6\FGS.Linq.Extensions.EntityFramework6.csproj", "{53495078-FCF8-4851-A07E-66CA3160EB3C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.EntityFrameworkCore", "src\FGS.Linq.Extensions.EntityFrameworkCore\FGS.Linq.Extensions.EntityFrameworkCore.csproj", "{2E8DE4EA-7E84-4D01-9A29-F03E69166566}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\FGS.Linq.Extensions.AutoMapper.Shared\FGS.Linq.Extensions.AutoMapper.Shared.projitems*{293e1465-e2e0-40c1-a28d-1bbd23961b55}*SharedItemsImports = 13
+		src\FGS.Linq.Extensions.EntityFramework.Shared\FGS.Linq.Extensions.EntityFramework.Shared.projitems*{a3e025be-c165-4bc4-bf83-a9bf5dc512e2}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -458,6 +465,14 @@ Global
 		{2483C4E7-E6CB-4E6C-9262-905F854DD803}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2483C4E7-E6CB-4E6C-9262-905F854DD803}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2483C4E7-E6CB-4E6C-9262-905F854DD803}.Release|Any CPU.Build.0 = Release|Any CPU
+		{53495078-FCF8-4851-A07E-66CA3160EB3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53495078-FCF8-4851-A07E-66CA3160EB3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53495078-FCF8-4851-A07E-66CA3160EB3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53495078-FCF8-4851-A07E-66CA3160EB3C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E8DE4EA-7E84-4D01-9A29-F03E69166566}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E8DE4EA-7E84-4D01-9A29-F03E69166566}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E8DE4EA-7E84-4D01-9A29-F03E69166566}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E8DE4EA-7E84-4D01-9A29-F03E69166566}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -536,6 +551,9 @@ Global
 		{32407A8B-39E5-43C2-B63A-F490D2578272} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 		{A78B4BDD-8538-4B1F-9016-1994E58DBEFA} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 		{2483C4E7-E6CB-4E6C-9262-905F854DD803} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{A3E025BE-C165-4BC4-BF83-A9BF5DC512E2} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{53495078-FCF8-4851-A07E-66CA3160EB3C} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{2E8DE4EA-7E84-4D01-9A29-F03E69166566} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9BE7FA6F-2D4E-4B5B-97B7-7D2DE8E3DB1E}

--- a/FGS.Foundation.sln
+++ b/FGS.Foundation.sln
@@ -157,19 +157,26 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Linq.Extensions.AutoMap
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Linq.Extensions.AutoMapper", "src\FGS.Linq.Extensions.AutoMapper\FGS.Linq.Extensions.AutoMapper.csproj", "{32407A8B-39E5-43C2-B63A-F490D2578272}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.Pagination.Abstractions", "src\FGS.Linq.Extensions.Pagination.Abstractions\FGS.Linq.Extensions.Pagination.Abstractions.csproj", "{A78B4BDD-8538-4B1F-9016-1994E58DBEFA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Linq.Extensions.Pagination.Abstractions", "src\FGS.Linq.Extensions.Pagination.Abstractions\FGS.Linq.Extensions.Pagination.Abstractions.csproj", "{A78B4BDD-8538-4B1F-9016-1994E58DBEFA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.Pagination", "src\FGS.Linq.Extensions.Pagination\FGS.Linq.Extensions.Pagination.csproj", "{2483C4E7-E6CB-4E6C-9262-905F854DD803}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Linq.Extensions.Pagination", "src\FGS.Linq.Extensions.Pagination\FGS.Linq.Extensions.Pagination.csproj", "{2483C4E7-E6CB-4E6C-9262-905F854DD803}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FGS.Linq.Extensions.EntityFramework.Shared", "src\FGS.Linq.Extensions.EntityFramework.Shared\FGS.Linq.Extensions.EntityFramework.Shared.shproj", "{A3E025BE-C165-4BC4-BF83-A9BF5DC512E2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.EntityFramework6", "src\FGS.Linq.Extensions.EntityFramework6\FGS.Linq.Extensions.EntityFramework6.csproj", "{53495078-FCF8-4851-A07E-66CA3160EB3C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Linq.Extensions.EntityFramework6", "src\FGS.Linq.Extensions.EntityFramework6\FGS.Linq.Extensions.EntityFramework6.csproj", "{53495078-FCF8-4851-A07E-66CA3160EB3C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.EntityFrameworkCore", "src\FGS.Linq.Extensions.EntityFrameworkCore\FGS.Linq.Extensions.EntityFrameworkCore.csproj", "{2E8DE4EA-7E84-4D01-9A29-F03E69166566}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Linq.Extensions.EntityFrameworkCore", "src\FGS.Linq.Extensions.EntityFrameworkCore\FGS.Linq.Extensions.EntityFrameworkCore.csproj", "{2E8DE4EA-7E84-4D01-9A29-F03E69166566}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FGS.Linq.Extensions.Pagination.EntityFramework.Shared", "src\FGS.Linq.Extensions.Pagination.EntityFramework.Shared\FGS.Linq.Extensions.Pagination.EntityFramework.Shared.shproj", "{96015FE6-1B5E-48F4-BCB3-464366C098F2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.Pagination.EntityFramework6", "src\FGS.Linq.Extensions.Pagination.EntityFramework6\FGS.Linq.Extensions.Pagination.EntityFramework6.csproj", "{8A64A5C6-2B3C-4BB2-B9FC-7C30B3F2B3E2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.Pagination.EntityFrameworkCore", "src\FGS.Linq.Extensions.Pagination.EntityFrameworkCore\FGS.Linq.Extensions.Pagination.EntityFrameworkCore.csproj", "{5B6E00E9-4217-45FB-93DA-0E822DC6B42D}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\FGS.Linq.Extensions.AutoMapper.Shared\FGS.Linq.Extensions.AutoMapper.Shared.projitems*{293e1465-e2e0-40c1-a28d-1bbd23961b55}*SharedItemsImports = 13
+		src\FGS.Linq.Extensions.Pagination.EntityFramework.Shared\FGS.Linq.Extensions.Pagination.EntityFramework.Shared.projitems*{96015fe6-1b5e-48f4-bcb3-464366c098f2}*SharedItemsImports = 13
 		src\FGS.Linq.Extensions.EntityFramework.Shared\FGS.Linq.Extensions.EntityFramework.Shared.projitems*{a3e025be-c165-4bc4-bf83-a9bf5dc512e2}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -473,6 +480,14 @@ Global
 		{2E8DE4EA-7E84-4D01-9A29-F03E69166566}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2E8DE4EA-7E84-4D01-9A29-F03E69166566}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2E8DE4EA-7E84-4D01-9A29-F03E69166566}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A64A5C6-2B3C-4BB2-B9FC-7C30B3F2B3E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A64A5C6-2B3C-4BB2-B9FC-7C30B3F2B3E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A64A5C6-2B3C-4BB2-B9FC-7C30B3F2B3E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A64A5C6-2B3C-4BB2-B9FC-7C30B3F2B3E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B6E00E9-4217-45FB-93DA-0E822DC6B42D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B6E00E9-4217-45FB-93DA-0E822DC6B42D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B6E00E9-4217-45FB-93DA-0E822DC6B42D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B6E00E9-4217-45FB-93DA-0E822DC6B42D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -554,6 +569,9 @@ Global
 		{A3E025BE-C165-4BC4-BF83-A9BF5DC512E2} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 		{53495078-FCF8-4851-A07E-66CA3160EB3C} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 		{2E8DE4EA-7E84-4D01-9A29-F03E69166566} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{96015FE6-1B5E-48F4-BCB3-464366C098F2} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{8A64A5C6-2B3C-4BB2-B9FC-7C30B3F2B3E2} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{5B6E00E9-4217-45FB-93DA-0E822DC6B42D} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9BE7FA6F-2D4E-4B5B-97B7-7D2DE8E3DB1E}

--- a/FGS.Foundation.sln
+++ b/FGS.Foundation.sln
@@ -153,9 +153,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Extensions.Hosting.Midd
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FGS.Linq.Extensions.AutoMapper.Shared", "src\FGS.Linq.Extensions.AutoMapper.Shared\FGS.Linq.Extensions.AutoMapper.Shared.shproj", "{293E1465-E2E0-40C1-A28D-1BBD23961B55}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.AutoMapper7", "src\FGS.Linq.Extensions.AutoMapper7\FGS.Linq.Extensions.AutoMapper7.csproj", "{4FF4041C-1809-4800-A378-A80560A05D03}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Linq.Extensions.AutoMapper7", "src\FGS.Linq.Extensions.AutoMapper7\FGS.Linq.Extensions.AutoMapper7.csproj", "{4FF4041C-1809-4800-A378-A80560A05D03}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Linq.Extensions.AutoMapper", "src\FGS.Linq.Extensions.AutoMapper\FGS.Linq.Extensions.AutoMapper.csproj", "{32407A8B-39E5-43C2-B63A-F490D2578272}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.Pagination.Abstractions", "src\FGS.Linq.Extensions.Pagination.Abstractions\FGS.Linq.Extensions.Pagination.Abstractions.csproj", "{A78B4BDD-8538-4B1F-9016-1994E58DBEFA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.Pagination", "src\FGS.Linq.Extensions.Pagination\FGS.Linq.Extensions.Pagination.csproj", "{2483C4E7-E6CB-4E6C-9262-905F854DD803}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -446,6 +450,14 @@ Global
 		{32407A8B-39E5-43C2-B63A-F490D2578272}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{32407A8B-39E5-43C2-B63A-F490D2578272}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{32407A8B-39E5-43C2-B63A-F490D2578272}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A78B4BDD-8538-4B1F-9016-1994E58DBEFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A78B4BDD-8538-4B1F-9016-1994E58DBEFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A78B4BDD-8538-4B1F-9016-1994E58DBEFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A78B4BDD-8538-4B1F-9016-1994E58DBEFA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2483C4E7-E6CB-4E6C-9262-905F854DD803}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2483C4E7-E6CB-4E6C-9262-905F854DD803}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2483C4E7-E6CB-4E6C-9262-905F854DD803}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2483C4E7-E6CB-4E6C-9262-905F854DD803}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -522,6 +534,8 @@ Global
 		{293E1465-E2E0-40C1-A28D-1BBD23961B55} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 		{4FF4041C-1809-4800-A378-A80560A05D03} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 		{32407A8B-39E5-43C2-B63A-F490D2578272} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{A78B4BDD-8538-4B1F-9016-1994E58DBEFA} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{2483C4E7-E6CB-4E6C-9262-905F854DD803} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9BE7FA6F-2D4E-4B5B-97B7-7D2DE8E3DB1E}

--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -61,6 +61,8 @@ parameters:
     58: FGS.Extensions.Hosting.Middleware.DelayedStart
     59: FGS.Linq.Extensions.AutoMapper
     60: FGS.Linq.Extensions.AutoMapper7
+    61: FGS.Linq.Extensions.Pagination.Abstractions
+    62: FGS.Linq.Extensions.Pagination
 
 stages:
 

--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -67,6 +67,9 @@ parameters:
     64: FGS.Linq.Extensions.EntityFrameworkCore
     65: FGS.Linq.Extensions.Pagination.EntityFramework6
     66: FGS.Linq.Extensions.Pagination.EntityFrameworkCore
+    67: FGS.Collections.Extensions.OneOf.Units
+    68: FGS.Linq.Extensions.OneOf.EntityFramework6
+    69: FGS.Linq.Extensions.OneOf.EntityFrameworkCore
 
 stages:
 

--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -63,6 +63,8 @@ parameters:
     60: FGS.Linq.Extensions.AutoMapper7
     61: FGS.Linq.Extensions.Pagination.Abstractions
     62: FGS.Linq.Extensions.Pagination
+    63: FGS.Linq.Extensions.EntityFramework6
+    64: FGS.Linq.Extensions.EntityFrameworkCore
 
 stages:
 

--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -59,6 +59,8 @@ parameters:
     56: FGS.Extensions.Hosting.Logging.Serilog
     57: FGS.Tests.Support.Extensions.Hosting.Middleware.Mocking
     58: FGS.Extensions.Hosting.Middleware.DelayedStart
+    59: FGS.Linq.Extensions.AutoMapper
+    60: FGS.Linq.Extensions.AutoMapper7
 
 stages:
 

--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -65,6 +65,8 @@ parameters:
     62: FGS.Linq.Extensions.Pagination
     63: FGS.Linq.Extensions.EntityFramework6
     64: FGS.Linq.Extensions.EntityFrameworkCore
+    65: FGS.Linq.Extensions.Pagination.EntityFramework6
+    66: FGS.Linq.Extensions.Pagination.EntityFrameworkCore
 
 stages:
 

--- a/src/FGS.Collections.Extensions.OneOf.Units/FGS.Collections.Extensions.OneOf.Units.csproj
+++ b/src/FGS.Collections.Extensions.OneOf.Units/FGS.Collections.Extensions.OneOf.Units.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
+
+    <Description>
+      Provides collection-query-related unit types to be used with discriminated unions.
+    </Description>
+    <PackageTags>OneOf;NoElements;MoreThanOneElement</PackageTags>
+
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/FGS.Collections.Extensions.OneOf.Units/MoreThanOneElement.cs
+++ b/src/FGS.Collections.Extensions.OneOf.Units/MoreThanOneElement.cs
@@ -1,0 +1,10 @@
+namespace FGS.Collections.Extensions.OneOf.Units
+{
+    /// <summary>
+    /// A unit type for usage in discriminated unions.
+    /// Signifies that only one element was expected, but more than one were found.
+    /// </summary>
+    public struct MoreThanOneElement
+    {
+    }
+}

--- a/src/FGS.Collections.Extensions.OneOf.Units/NoElements.cs
+++ b/src/FGS.Collections.Extensions.OneOf.Units/NoElements.cs
@@ -1,0 +1,10 @@
+namespace FGS.Collections.Extensions.OneOf.Units
+{
+    /// <summary>
+    /// A unit type for usage in discriminated unions.
+    /// Signifies that an element was expected, but none were found.
+    /// </summary>
+    public struct NoElements
+    {
+    }
+}

--- a/src/FGS.Collections.Extensions.Pagination.Abstractions/FGS.Collections.Extensions.Pagination.Abstractions.csproj
+++ b/src/FGS.Collections.Extensions.Pagination.Abstractions/FGS.Collections.Extensions.Pagination.Abstractions.csproj
@@ -7,7 +7,10 @@
     <Description>
       Provides abstractions used as part of adding pagination support to LINQ.
     </Description>
-    <PackageTags>collections;linq;pagination</PackageTags>
+    <PackageTags>collections;linq;pagination;paging;pager;paged</PackageTags>
+
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/src/FGS.Linq.Expressions/FGS.Linq.Expressions.csproj
+++ b/src/FGS.Linq.Expressions/FGS.Linq.Expressions.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -8,7 +8,10 @@
     <Description>
       Provides the ability to manipulate LINQ expression trees.
     </Description>
-    <PackageTags>LINQ;lambda;expressions;ParameterReplacer</PackageTags>
+    <PackageTags>LINQ;lambda;expressions;ParameterReplacer;CreateScalarQuery</PackageTags>
+
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/src/FGS.Linq.Expressions/QueryProviderExtensions.cs
+++ b/src/FGS.Linq.Expressions/QueryProviderExtensions.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace FGS.Linq.Expressions
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="IQueryProvider"/>.
+    /// </summary>
+    public static class QueryProviderExtensions
+    {
+        /// <summary>
+        /// Wraps a non-<see cref="IQueryable{T}"/> query as a subselect and returns it as an <see cref="IQueryable{T}"/>.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the single row that will be in the result of the query.</typeparam>
+        /// <param name="queryProvider">The <see cref="IQueryProvider"/> that can translate expression trees into queries against an underlying storage mechanism.</param>
+        /// <param name="selectExpression">An expression that selects a single value or anonymous object that is projected via expressions that can be converted into one or more subqueries.</param>
+        /// <returns>An <see cref="IQueryable{T}"/> that selects a single row of one or more values that are projected by subqueries.</returns>
+        /// <remarks>
+        /// <para>
+        /// Taken and modified from: https://stackoverflow.com/a/8996021.
+        /// </para>
+        /// <para>
+        /// Callers are responsible for authoring subqueries in such a way that the given <paramref name="queryProvider"/> can interpret it.
+        /// </para>
+        /// </remarks>
+        public static IQueryable<TResult> CreateScalarQuery<TResult>(this IQueryProvider queryProvider, Expression<Func<TResult>> selectExpression)
+        {
+            MethodInfo GetMethodInfo(Expression<Action> lambdaOfMethodCallExpression)
+            {
+                return ((MethodCallExpression)lambdaOfMethodCallExpression.Body).Method;
+            }
+
+            return queryProvider.CreateQuery<TResult>(
+                Expression.Call(
+                    method: GetMethodInfo(() => Queryable.Select(null, (Expression<Func<int, TResult>>)null)),
+                    arg0: Expression.Call(
+                        method: GetMethodInfo(() => Queryable.AsQueryable<int>(null)),
+                        arg0: Expression.NewArrayInit(typeof(int), Expression.Constant(1))),
+                    arg1: Expression.Lambda(body: selectExpression.Body, parameters: new[] { Expression.Parameter(typeof(int)) })));
+        }
+    }
+}

--- a/src/FGS.Linq.Extensions.AutoMapper.Shared/AutoMapperQueryableExtensions.cs
+++ b/src/FGS.Linq.Extensions.AutoMapper.Shared/AutoMapperQueryableExtensions.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using AutoMapper;
+
+namespace FGS.Linq.Extensions.AutoMapper
+{
+    /// <summary>
+    /// Extends <see cref="IQueryable{T}"/> with the ability to transform it into a query of a different type, using AutoMapper.
+    /// </summary>
+    public static class AutoMapperQueryableExtensions
+    {
+        /// <summary>
+        /// Projects a query into a new output type, using <paramref name="mapper"/>.
+        /// </summary>
+        /// <typeparam name="TSource">The type of items in the source query.</typeparam>
+        /// <typeparam name="TDestination">The type of items in the result query.</typeparam>
+        /// <param name="source">The original query that is being transformed.</param>
+        /// <param name="mapper">The mapper that converts the query.</param>
+        /// <returns>A query of items of type <typeparamref name="TDestination"/>.</returns>
+        public static IQueryable<TDestination> Map<TSource, TDestination>(this IQueryable<TSource> source, IMapper mapper)
+        {
+#if PROJECTTO_IS_EXTENSION
+            return global::AutoMapper.QueryableExtensions.Extensions.ProjectTo<TDestination>(source, mapper.ConfigurationProvider);
+#elif PROJECTTO_IS_MEMBER
+            return mapper.ProjectTo<TDestination>(source);
+#else
+            throw new NotImplementedException();
+#endif
+        }
+    }
+}

--- a/src/FGS.Linq.Extensions.AutoMapper.Shared/FGS.Linq.Extensions.AutoMapper.Shared.projitems
+++ b/src/FGS.Linq.Extensions.AutoMapper.Shared/FGS.Linq.Extensions.AutoMapper.Shared.projitems
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>293e1465-e2e0-40c1-a28d-1bbd23961b55</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>FGS.Linq.Extensions.AutoMapper.Shared</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)AutoMapperQueryableExtensions.cs" />
+  </ItemGroup>
+</Project>

--- a/src/FGS.Linq.Extensions.AutoMapper.Shared/FGS.Linq.Extensions.AutoMapper.Shared.shproj
+++ b/src/FGS.Linq.Extensions.AutoMapper.Shared/FGS.Linq.Extensions.AutoMapper.Shared.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>293e1465-e2e0-40c1-a28d-1bbd23961b55</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="FGS.Linq.Extensions.AutoMapper.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/src/FGS.Linq.Extensions.AutoMapper/FGS.Linq.Extensions.AutoMapper.csproj
+++ b/src/FGS.Linq.Extensions.AutoMapper/FGS.Linq.Extensions.AutoMapper.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);PROJECTTO_IS_MEMBER</DefineConstants>
+
+    <Description>
+      Provides an extension method to project queries from one type to queries of another, using AutoMapper - essentially a white-labelling of AutoMapper's `ProjectTo` construct, albeit stable across AutoMapper versions.
+
+      This package is for AutoMapper versions 8-9. For an identical API on AutoMapper versions 6-7, see `FGS.Linq.Extensions.AutoMapper7`.
+    </Description>
+    <PackageTags>LINQ;lambda;expressions;AutoMapper;ProjectTo;Map</PackageTags>
+
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="[8.0.0, 9.0.0]" />
+  </ItemGroup>
+
+  <Import Project="..\FGS.Linq.Extensions.AutoMapper.Shared\FGS.Linq.Extensions.AutoMapper.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/src/FGS.Linq.Extensions.AutoMapper7/FGS.Linq.Extensions.AutoMapper7.csproj
+++ b/src/FGS.Linq.Extensions.AutoMapper7/FGS.Linq.Extensions.AutoMapper7.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);PROJECTTO_IS_EXTENSION</DefineConstants>
+
+    <Description>
+      Provides an extension method to project queries from one type to queries of another, using AutoMapper - essentially a white-labelling of AutoMapper's `ProjectTo` construct, albeit stable across AutoMapper versions.
+
+      This package is for AutoMapper versions 6-7. For an identical API on AutoMapper versions 8-9, see `FGS.Linq.Extensions.AutoMapper`.
+    </Description>
+    <PackageTags>LINQ;lambda;expressions;AutoMapper;ProjectTo;Map</PackageTags>
+
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="[6.0.2, 8.0.0)" />
+  </ItemGroup>
+
+  <Import Project="..\FGS.Linq.Extensions.AutoMapper.Shared\FGS.Linq.Extensions.AutoMapper.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/src/FGS.Linq.Extensions.EntityFramework.Shared/FGS.Linq.Extensions.EntityFramework.Shared.projitems
+++ b/src/FGS.Linq.Extensions.EntityFramework.Shared/FGS.Linq.Extensions.EntityFramework.Shared.projitems
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>a3e025be-c165-4bc4-bf83-a9bf5dc512e2</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>FGS.Linq.Extensions.EntityFramework.Shared</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)MaterializingQueryableExtensions.cs" />
+  </ItemGroup>
+</Project>

--- a/src/FGS.Linq.Extensions.EntityFramework.Shared/FGS.Linq.Extensions.EntityFramework.Shared.shproj
+++ b/src/FGS.Linq.Extensions.EntityFramework.Shared/FGS.Linq.Extensions.EntityFramework.Shared.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>a3e025be-c165-4bc4-bf83-a9bf5dc512e2</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="FGS.Linq.Extensions.EntityFramework.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/src/FGS.Linq.Extensions.EntityFramework.Shared/MaterializingQueryableExtensions.cs
+++ b/src/FGS.Linq.Extensions.EntityFramework.Shared/MaterializingQueryableExtensions.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+#if EF6
+using System.Data.Entity;
+#endif
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+#if EFCORE
+using Microsoft.EntityFrameworkCore;
+#endif
+
+namespace FGS.Linq.Extensions.EntityFramework
+{
+    /// <summary>
+    /// Extends <see cref="IQueryable{T}"/> with a facade of materialization methods.
+    /// </summary>
+    public static class MaterializingQueryableExtensions
+    {
+        /// <summary>
+        /// Asynchronously executes the query represented by <paramref name="source"/> and returns all of the results.
+        /// </summary>
+        /// <typeparam name="T">The type of items that <paramref name="source"/> queries for.</typeparam>
+        /// <param name="source">The source query.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the materialization to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="IReadOnlyList{T}"/> that contains elements from the input query.</returns>
+        public static async Task<IReadOnlyList<T>> MaterializeAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken = default) =>
+            (await source.ToListAsync(cancellationToken).ConfigureAwait(false)).AsReadOnly();
+
+        /// <summary>
+        /// Asynchronously returns a single element from the query represented by <paramref name="source"/>, and throws an exception if there is not exactly one element.
+        /// </summary>
+        /// <typeparam name="T">The type of items that <paramref name="source"/> queries for.</typeparam>
+        /// <param name="source">The source query.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the materialization to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the single element from the input query.</returns>
+        public static Task<T> MaterializeSingleAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken = default) =>
+            source.SingleAsync(cancellationToken);
+
+        /// <summary>
+        /// Asynchronously returns a single element from the query represented by <paramref name="source"/>, returns <see langword="null"/> if there are no elements, and throws an exception if there is more than one element.
+        /// </summary>
+        /// <typeparam name="T">The type of items that <paramref name="source"/> queries for.</typeparam>
+        /// <param name="source">The source query.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the materialization to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the single element from the input query.</returns>
+        public static Task<T> MaterializeSingleOrDefaultAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken = default) =>
+            source.SingleOrDefaultAsync(cancellationToken);
+
+        /// <summary>
+        /// Asynchronously returns the first element from the query represented by <paramref name="source"/>, and throws an exception if there are no elements.
+        /// </summary>
+        /// <typeparam name="T">The type of items that <paramref name="source"/> queries for.</typeparam>
+        /// <param name="source">The source query.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the materialization to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the first element from the input query.</returns>
+        public static Task<T> MaterializeFirstAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken = default) =>
+            source.FirstAsync(cancellationToken);
+
+        /// <summary>
+        /// Asynchronously returns the first element from the query represented by <paramref name="source"/>, and returns <see langword="null"/> if there are no elements.
+        /// </summary>
+        /// <typeparam name="T">The type of items that <paramref name="source"/> queries for.</typeparam>
+        /// <param name="source">The source query.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the materialization to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the first element from the input query.</returns>
+        public static Task<T> MaterializeFirstOrDefaultAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken = default) =>
+            source.FirstOrDefaultAsync(cancellationToken);
+#if EF_CORE
+
+        /// <summary>
+        /// Asynchronously returns the last element from the query represented by <paramref name="source"/>, and throws an exception if there are no elements.
+        /// </summary>
+        /// <typeparam name="T">The type of items that <paramref name="source"/> queries for.</typeparam>
+        /// <param name="source">The source query.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the materialization to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the last element from the input query.</returns>
+        public static Task<T> MaterializeLastAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken = default) =>
+            source.LastAsync(cancellationToken);
+
+        /// <summary>
+        /// Asynchronously returns the last element from the query represented by <paramref name="source"/>, and returns <see langword="null"/> if there are no elements.
+        /// </summary>
+        /// <typeparam name="T">The type of items that <paramref name="source"/> queries for.</typeparam>
+        /// <param name="source">The source query.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the materialization to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the last element from the input query.</returns>
+        public static Task<T> MaterializeLastOrDefaultAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken = default) =>
+            source.LastOrDefaultAsync(cancellationToken);
+#endif
+    }
+}

--- a/src/FGS.Linq.Extensions.EntityFramework6/FGS.Linq.Extensions.EntityFramework6.csproj
+++ b/src/FGS.Linq.Extensions.EntityFramework6/FGS.Linq.Extensions.EntityFramework6.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netstandard2.1;netcoreapp3.0</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);EF6</DefineConstants>
+
+    <Description>
+      Provides extension methods to materialize query results  - essentially a white-labelling of EF's `XAsync()` extension methods, albeit with names that explicitly convey the concept of materialization as the intent.
+
+      This package is for Entity Framework 6.x. For an identical API on Entity Framework Core, see `FGS.Linq.Extensions.EntityFrameworkCore`.
+    </Description>
+    <PackageTags>LINQ;EntityFramework;EF;EntityFramework6;EF6;materialize</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="EntityFramework" Version="[6.0.0, 6.3.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="EntityFramework" Version="[6.3.0, 6.5.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="EntityFramework" Version="[6.3.0, 6.5.0)" />
+  </ItemGroup>
+  
+  <Import Project="..\FGS.Linq.Extensions.EntityFramework.Shared\FGS.Linq.Extensions.EntityFramework.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/src/FGS.Linq.Extensions.EntityFrameworkCore/FGS.Linq.Extensions.EntityFrameworkCore.csproj
+++ b/src/FGS.Linq.Extensions.EntityFrameworkCore/FGS.Linq.Extensions.EntityFrameworkCore.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);EFCORE</DefineConstants>
+
+    <Description>
+      Provides extension methods to materialize query results - essentially a white-labelling of EF's `XAsync()` extension methods, albeit with names that explicitly convey the concept of materialization as the intent.
+
+      This package is for Entity Framework Core. For an identical API on Entity Framework 6.x, see `FGS.Linq.Extensions.EntityFramework6`.
+    </Description>
+    <PackageTags>LINQ;EntityFramework;EF;EntityFrameworkCore;EFCore;materialize</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[1.0.0, 3.0.0)" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[1.0.0, 3.1.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.0.0, 3.1.0)" />
+  </ItemGroup>
+
+  <Import Project="..\FGS.Linq.Extensions.EntityFramework.Shared\FGS.Linq.Extensions.EntityFramework.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/src/FGS.Linq.Extensions.OneOf.EntityFramework.Shared/FGS.Linq.Extensions.OneOf.EntityFramework.Shared.projitems
+++ b/src/FGS.Linq.Extensions.OneOf.EntityFramework.Shared/FGS.Linq.Extensions.OneOf.EntityFramework.Shared.projitems
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>8a11571f-0de7-4e1f-8c1d-6a441f3eaa85</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>FGS.Linq.Extensions.OneOf.EntityFramework.Shared</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)OneOfQueryableExtensions.cs" />
+  </ItemGroup>
+</Project>

--- a/src/FGS.Linq.Extensions.OneOf.EntityFramework.Shared/FGS.Linq.Extensions.OneOf.EntityFramework.Shared.shproj
+++ b/src/FGS.Linq.Extensions.OneOf.EntityFramework.Shared/FGS.Linq.Extensions.OneOf.EntityFramework.Shared.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>8a11571f-0de7-4e1f-8c1d-6a441f3eaa85</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="FGS.Linq.Extensions.OneOf.EntityFramework.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/src/FGS.Linq.Extensions.OneOf.EntityFramework.Shared/OneOfQueryableExtensions.cs
+++ b/src/FGS.Linq.Extensions.OneOf.EntityFramework.Shared/OneOfQueryableExtensions.cs
@@ -1,0 +1,77 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+#if EF6
+using System.Data.Entity;
+#endif
+using FGS.Collections.Extensions.OneOf.Units;
+using FGS.Linq.Extensions.EntityFramework;
+#if EFCORE
+using Microsoft.EntityFrameworkCore;
+#endif
+using OneOf;
+
+namespace FGS.Linq.Extensions.OneOf.EntityFramework
+{
+    /// <summary>
+    /// Extends <see cref="IQueryable{T}"/> with a materialization methods that describe their failure conditions using discriminated unions.
+    /// </summary>
+    public static class OneOfQueryableExtensions
+    {
+        /// <summary>
+        /// Asynchronously returns a single element from the query represented by <paramref name="source"/>, returns <see cref="NoElements"/> if there are no elements, returns <see cref="MoreThanOneElement"/> if there is more than one element.
+        /// </summary>
+        /// <typeparam name="T">The type of items that <paramref name="source"/> queries for.</typeparam>
+        /// <param name="source">The source query.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the materialization to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the single element from the input query, or the reason why it could be returned.</returns>
+        public static async Task<OneOf<T, NoElements, MoreThanOneElement>> MaterializeSingleOrReasonWhyNot<T>(this IQueryable<T> source, CancellationToken cancellationToken = default)
+        {
+            var firstOrDefault = await source.MaterializeFirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            var anyMore = await source.Skip(1).AnyAsync(cancellationToken).ConfigureAwait(false);
+
+            if (anyMore)
+                return default(MoreThanOneElement);
+            else if (firstOrDefault != null)
+                return firstOrDefault;
+            else
+                return default(NoElements);
+        }
+
+        /// <summary>
+        /// Asynchronously returns the first element from the query represented by <paramref name="source"/>, and returns <see cref="NoElements"/> if there are no elements.
+        /// </summary>
+        /// <typeparam name="T">The type of items that <paramref name="source"/> queries for.</typeparam>
+        /// <param name="source">The source query.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the materialization to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the first element from the input query, or the reason why it could be returned.</returns>
+        public static async Task<OneOf<T, NoElements>> MaterializeFirstOrReasonWhyNot<T>(this IQueryable<T> source, CancellationToken cancellationToken = default)
+        {
+            var firstOrDefault = await source.MaterializeFirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+            if (firstOrDefault != null)
+                return firstOrDefault;
+            else
+                return default(NoElements);
+        }
+#if EF_CORE
+
+        /// <summary>
+        /// Asynchronously returns the last element from the query represented by <paramref name="source"/>, and returns <see cref="NoElements"/> if there are no elements.
+        /// </summary>
+        /// <typeparam name="T">The type of items that <paramref name="source"/> queries for.</typeparam>
+        /// <param name="source">The source query.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the materialization to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the last element from the input query, or the reason why it could be returned.</returns>
+        public static Task<OneOf<T, NoElements>> MaterializeLastOrReasonWhyNot<T>(this IQueryable<T> source, CancellationToken cancellationToken = default)
+        {
+            var lastOrDefault = await source.MaterializeLastOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+            if (lastOrDefault != null)
+                return lastOrDefault;
+            else
+                return default(NoElements);
+        }
+#endif
+    }
+}

--- a/src/FGS.Linq.Extensions.OneOf.EntityFramework6/FGS.Linq.Extensions.OneOf.EntityFramework6.csproj
+++ b/src/FGS.Linq.Extensions.OneOf.EntityFramework6/FGS.Linq.Extensions.OneOf.EntityFramework6.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netstandard2.1;netcoreapp3.0</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);EF6</DefineConstants>
+
+    <Description>
+      Provides extension methods to materialize query results while describing failures using discriminated unions.
+
+      An `IQueryable` version of `OneOf.Linq`.
+
+      This package is for Entity Framework 6.x. For an identical API on Entity Framework Core, see `FGS.Linq.Extensions.EntityFrameworkCore`.
+    </Description>
+    <PackageTags>EntityFramework;EF;EntityFramework6;EF6;materialize;discriminated unions;match;switch</PackageTags>
+
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="EntityFramework" Version="[6.0.0, 6.3.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="EntityFramework" Version="[6.3.0, 6.5.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="EntityFramework" Version="[6.3.0, 6.5.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OneOf" Version="[2.0.17, 3.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FGS.Collections.Extensions.OneOf.Units\FGS.Collections.Extensions.OneOf.Units.csproj" />
+    <ProjectReference Include="..\FGS.Linq.Extensions.EntityFramework6\FGS.Linq.Extensions.EntityFramework6.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\FGS.Linq.Extensions.OneOf.EntityFramework.Shared\FGS.Linq.Extensions.OneOf.EntityFramework.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/src/FGS.Linq.Extensions.OneOf.EntityFrameworkCore/FGS.Linq.Extensions.OneOf.EntityFrameworkCore.csproj
+++ b/src/FGS.Linq.Extensions.OneOf.EntityFrameworkCore/FGS.Linq.Extensions.OneOf.EntityFrameworkCore.csproj
@@ -1,0 +1,43 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);EFCORE</DefineConstants>
+
+    <Description>
+      Provides extension methods to materialize query results while describing failures using discriminated unions.
+
+      An `IQueryable` version of `OneOf.Linq`.
+
+      This package is for Entity Framework Core. For an identical API on Entity Framework 6.x, see `FGS.Linq.Extensions.EntityFramework6`.
+    </Description>
+    <PackageTags>EntityFramework;EF;EntityFrameworkCore;EFCore;materialize;discriminated unions;match;switch</PackageTags>
+
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[1.0.0, 3.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[1.0.0, 3.1.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.0.0, 3.1.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OneOf" Version="[2.0.17, 3.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FGS.Collections.Extensions.OneOf.Units\FGS.Collections.Extensions.OneOf.Units.csproj" />
+    <ProjectReference Include="..\FGS.Linq.Extensions.EntityFrameworkCore\FGS.Linq.Extensions.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\FGS.Linq.Extensions.OneOf.EntityFramework.Shared\FGS.Linq.Extensions.OneOf.EntityFramework.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/src/FGS.Linq.Extensions.Pagination.Abstractions/FGS.Linq.Extensions.Pagination.Abstractions.csproj
+++ b/src/FGS.Linq.Extensions.Pagination.Abstractions/FGS.Linq.Extensions.Pagination.Abstractions.csproj
@@ -1,13 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
 
     <Description>
-      Provides extension methods to augment LINQ-to-Objects with pagination.
+      Provides abstractions used as part of adding pagination support to LINQ-to-IQueryable.
     </Description>
-    <PackageTags>collections;linq;pagination;paging;pager;paged</PackageTags>
+    <PackageTags>IQueryable;linq;pagination;paging;pager;paged</PackageTags>
 
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/FGS.Linq.Extensions.Pagination.Abstractions/PageQuery.cs
+++ b/src/FGS.Linq.Extensions.Pagination.Abstractions/PageQuery.cs
@@ -1,0 +1,40 @@
+using FGS.Collections.Extensions.Pagination.Abstractions;
+using System.Linq;
+
+namespace FGS.Linq.Extensions.Pagination.Abstractions
+{
+    /// <summary>
+    /// Represents a query of a page of items taken from a larger set of items.
+    /// </summary>
+    /// <typeparam name="T">The type of items in the page.</typeparam>
+    public class PageQuery<T>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PageQuery{T}"/> class.
+        /// </summary>
+        /// <param name="items">The query of the items on this page.</param>
+        /// <param name="paginationSpecification">The specification of how the items for this page are selected.</param>
+        /// <param name="hasNextPage">A query of single <see cref="bool"/> evaluating whether or not future pages are expected, given the original source and an incremented <see cref="PaginationSpecification"/>.</param>
+        public PageQuery(IQueryable<T> items, PaginationSpecification paginationSpecification, IQueryable<bool> hasNextPage)
+        {
+            Items = items;
+            PaginationSpecification = paginationSpecification;
+            HasNextPage = hasNextPage;
+        }
+
+        /// <summary>
+        /// Gets a query of the items on this page.
+        /// </summary>
+        public IQueryable<T> Items { get; }
+
+        /// <summary>
+        /// Gets the specification of how the items for this page are selected.
+        /// </summary>
+        public PaginationSpecification PaginationSpecification { get; }
+
+        /// <summary>
+        /// Gets a query that evaluates a single <see cref="bool"/> value that indicates whether or not future pages are expected, given the original source and an incremented <see cref="PaginationSpecification"/>.
+        /// </summary>
+        public IQueryable<bool> HasNextPage { get; }
+    }
+}

--- a/src/FGS.Linq.Extensions.Pagination.EntityFramework.Shared/FGS.Linq.Extensions.Pagination.EntityFramework.Shared.projitems
+++ b/src/FGS.Linq.Extensions.Pagination.EntityFramework.Shared/FGS.Linq.Extensions.Pagination.EntityFramework.Shared.projitems
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>96015fe6-1b5e-48f4-bcb3-464366c098f2</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>FGS.Linq.Extensions.Pagination.EntityFramework.Shared</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)PageQueryExtensions.cs" />
+  </ItemGroup>
+</Project>

--- a/src/FGS.Linq.Extensions.Pagination.EntityFramework.Shared/FGS.Linq.Extensions.Pagination.EntityFramework.Shared.shproj
+++ b/src/FGS.Linq.Extensions.Pagination.EntityFramework.Shared/FGS.Linq.Extensions.Pagination.EntityFramework.Shared.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>96015fe6-1b5e-48f4-bcb3-464366c098f2</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="FGS.Linq.Extensions.Pagination.EntityFramework.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/src/FGS.Linq.Extensions.Pagination.EntityFramework.Shared/PageQueryExtensions.cs
+++ b/src/FGS.Linq.Extensions.Pagination.EntityFramework.Shared/PageQueryExtensions.cs
@@ -1,0 +1,27 @@
+using FGS.Collections.Extensions.Pagination.Abstractions;
+using FGS.Linq.Extensions.EntityFramework;
+using FGS.Linq.Extensions.Pagination.Abstractions;
+using System.Threading.Tasks;
+
+namespace FGS.Linq.Extensions.Pagination.EntityFramework
+{
+    /// <summary>
+    /// Extends <see cref="PageQuery{T}"/> with materialization functionality.
+    /// </summary>
+    public static class PageQueryExtensions
+    {
+        /// <summary>
+        /// Asynchronously materializes <paramref name="self"/> into a <see cref="Page{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of item on the page.</typeparam>
+        /// <param name="self">The source representation of a paginated query that will be materialized.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="Page{T}"/> that contains elements from the input query.</returns>
+        public static async Task<Page<T>> MaterializeAsync<T>(this PageQuery<T> self)
+        {
+            var items = await self.Items.MaterializeAsync().ConfigureAwait(false);
+            var hasNextPage = await self.HasNextPage.MaterializeSingleOrDefaultAsync().ConfigureAwait(false);
+
+            return new Page<T>(items, self.PaginationSpecification, hasNextPage);
+        }
+    }
+}

--- a/src/FGS.Linq.Extensions.Pagination.EntityFramework6/FGS.Linq.Extensions.Pagination.EntityFramework6.csproj
+++ b/src/FGS.Linq.Extensions.Pagination.EntityFramework6/FGS.Linq.Extensions.Pagination.EntityFramework6.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netstandard2.1;netcoreapp3.0</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);EF6</DefineConstants>
+
+    <Description>
+      Provides an extension method to materialize a paginated query.
+
+      This package is for Entity Framework 6.x. For an identical API on Entity Framework Core, see `FGS.Linq.Extensions.Pagination.EntityFrameworkCore`.
+    </Description>
+    <PackageTags>pagination;paging;pager;paged;pagequery;EntityFramework;EF;EntityFramework6;EF6;materialize</PackageTags>
+
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FGS.Linq.Extensions.EntityFramework6\FGS.Linq.Extensions.EntityFramework6.csproj" />
+    <ProjectReference Include="..\FGS.Linq.Extensions.Pagination.Abstractions\FGS.Linq.Extensions.Pagination.Abstractions.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\FGS.Linq.Extensions.Pagination.EntityFramework.Shared\FGS.Linq.Extensions.Pagination.EntityFramework.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/src/FGS.Linq.Extensions.Pagination.EntityFrameworkCore/FGS.Linq.Extensions.Pagination.EntityFrameworkCore.csproj
+++ b/src/FGS.Linq.Extensions.Pagination.EntityFrameworkCore/FGS.Linq.Extensions.Pagination.EntityFrameworkCore.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);EFCORE</DefineConstants>
+
+    <Description>
+      Provides an extension method to materialize a paginated query.
+
+      This package is for Entity Framework Core. For an identical API on Entity Framework 6.x, see `FGS.Linq.Extensions.Pagination.EntityFramework6`.
+    </Description>
+    <PackageTags>pagination;paging;pager;paged;pagequery;EntityFramework;EF;EntityFrameworkCore;EFCore;materialize</PackageTags>
+
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FGS.Linq.Extensions.EntityFrameworkCore\FGS.Linq.Extensions.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\FGS.Linq.Extensions.Pagination.Abstractions\FGS.Linq.Extensions.Pagination.Abstractions.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\FGS.Linq.Extensions.Pagination.EntityFramework.Shared\FGS.Linq.Extensions.Pagination.EntityFramework.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/src/FGS.Linq.Extensions.Pagination/FGS.Linq.Extensions.Pagination.csproj
+++ b/src/FGS.Linq.Extensions.Pagination/FGS.Linq.Extensions.Pagination.csproj
@@ -1,13 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0;netstandard2.1;netcoreapp3.0</TargetFrameworks>
 
     <Description>
-      Provides extension methods to augment LINQ-to-Objects with pagination.
+      Provides extension methods to augment LINQ-to-IQueryable with pagination.
     </Description>
-    <PackageTags>collections;linq;pagination;paging;pager;paged</PackageTags>
+    <PackageTags>IQueryable;linq;pagination;paging;pager;paged</PackageTags>
 
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
@@ -15,6 +14,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FGS.Collections.Extensions.Pagination.Abstractions\FGS.Collections.Extensions.Pagination.Abstractions.csproj" />
+    <ProjectReference Include="..\FGS.Linq.Expressions\FGS.Linq.Expressions.csproj" />
+    <ProjectReference Include="..\FGS.Linq.Extensions.Pagination.Abstractions\FGS.Linq.Extensions.Pagination.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/FGS.Linq.Extensions.Pagination/PaginationQueryableExtensions.cs
+++ b/src/FGS.Linq.Extensions.Pagination/PaginationQueryableExtensions.cs
@@ -1,0 +1,32 @@
+using FGS.Collections.Extensions.Pagination.Abstractions;
+using FGS.Linq.Expressions;
+using FGS.Linq.Extensions.Pagination.Abstractions;
+using System.Linq;
+
+namespace FGS.Linq.Extensions.Pagination
+{
+    /// <summary>
+    /// Extends <see cref="IQueryable{T}"/> with pagination capabilities.
+    /// </summary>
+    public static class PaginationQueryableExtensions
+    {
+        /// <summary>
+        /// Returns a query of a paginated subsection of the original <paramref name="source"/>, paginated based on <paramref name="paginationSpecification"/>.
+        /// </summary>
+        /// <param name="source">The query of items to paginate.</param>
+        /// <param name="paginationSpecification">Specifies how the <paramref name="source"/> should be paginated.</param>
+        /// <typeparam name="T">The type of items to paginate.</typeparam>
+        /// <returns>A <see cref="PageQuery{T}"/> representing the paginated results.</returns>
+        /// <remarks>Assumes <paramref name="source.Provider"/> is able to translate and evaluate queries generated via <see cref="FGS.Linq.Expressions.QueryProviderExtensions.CreateScalarQuery{TResult}(IQueryProvider, System.Linq.Expressions.Expression{System.Func{TResult}})"/>.</remarks>
+        public static PageQuery<T> Paginate<T>(this IQueryable<T> source, PaginationSpecification paginationSpecification)
+        {
+            var queryOfItemsOnResultPagePlusEverAfter = source.Skip(paginationSpecification.PageNumber * paginationSpecification.PageSize);
+            var queryOfItemsOnResultPage = queryOfItemsOnResultPagePlusEverAfter.Take(paginationSpecification.PageSize);
+            var queryOfItemAfterResultPage = queryOfItemsOnResultPagePlusEverAfter.Skip(paginationSpecification.PageSize).Take(1);
+
+            var queryOfAnyItemAfterResultPage = source.Provider.CreateScalarQuery(() => queryOfItemAfterResultPage.Any());
+
+            return new PageQuery<T>(queryOfItemsOnResultPage, paginationSpecification, queryOfAnyItemAfterResultPage);
+        }
+    }
+}


### PR DESCRIPTION
This creates a large set of new packages designed to give a consistent API around mapping, paginating, and materializing query results - all while aiming to be aligned with FoxGuard's existing habits for same. This also makes a best effort to support both Entity Framework 6.x and Entity Framework Core as identically as possible.

Most of this functionality already exists - in one form or another - in our disparate codebases, and this is just a refactoring of them. The only new-to-us concept being added here is the ability to materialize queries in a way that explains failures using discriminated unions.

## APIs Added

### For All `IQueryable<T>`:

#### `FGS.Linq.Extensions.AutoMapper`
- `.Map()` -> `IQueryable<T2>`

#### `FGS.Linq.Extensions.Pagination`
- `.Paginate()` -> `PageQuery<T>`

### For `IQueryable<T>` on EF6:

#### `FGS.Linq.Extensions.EntityFramework6`
- `.MaterializeAsync()` -> `IReadOnlyList<T>`
- `.MaterializeSingleAsync()` -> `T` || _thrown `Exception`_
- `.MaterializeSingleOrDefaultAsync()` -> `T` || `null`
- `.MaterializeFirstAsync()` -> `T` || _thrown `Exception`_
- `.MaterializeFirstOrDefaultAsync()` -> `T` || `null`
- ~`.MaterializeLastAsync()` -> `T` || _thrown `Exception`_~
- ~`.MaterializeLastOrDefaultAsync()` -> `T` || `null`~

### For `IQueryable<T>` on EFCore:

#### `FGS.Linq.Extensions.EntityFrameworkCore`
- `.MaterializeAsync()` -> `IReadOnlyList<T>`
- `.MaterializeSingleAsync()` -> `T` || _thrown `Exception`_
- `.MaterializeSingleOrDefaultAsync()` -> `T` || `null`
- `.MaterializeFirstAsync()` -> `T` || _thrown `Exception`_
- `.MaterializeFirstOrDefaultAsync()` -> `T` || `null`
- `.MaterializeLastAsync()` -> `T` || _thrown `Exception`_
- `.MaterializeLastOrDefaultAsync()` -> `T` || `null`

### For `PageQuery<T>` on EF6:

#### `FGS.Linq.Extensions.Pagination.EntityFramework6`
- `.MaterializeAsync()` -> `Page<T>`

### For `PageQuery<T>` on EFCore:
	
#### `FGS.Linq.Extensions.Pagination.EntityFrameworkCore`
- `.MaterializeAsync()` -> `Page<T>`

### For `IQueryable<T>` on EF6 + OneOf (and + our own version of [OneOf.Linq](https://github.com/ndrwrbgs/OneOf.Linq)):

#### `FGS.Linq.Extensions.OneOf.EntityFramework6`
- `.MaterializeSingleOrReasonWhyNotAsync()` -> `OneOf<T, NoElements, MoreThanOneElement>`
- `.MaterializeFirstOrReasonWhyNotAsync()` -> `OneOf<T, NoElements>`
- ~`.MaterializeLastOrReasonWhyNotAsync()` -> `OneOf<T, NoElements>`~

### For `IQueryable<T>` on EFCore + OneOf (and + our own version of [OneOf.Linq](https://github.com/ndrwrbgs/OneOf.Linq)):
	
#### `FGS.Linq.Extensions.OneOf.EntityFrameworkCore`
- `.MaterializeSingleOrReasonWhyNotAsync()` -> `OneOf<T, NoElements, MoreThanOneElement>`
- `.MaterializeFirstOrReasonWhyNotAsync()` -> `OneOf<T, NoElements>`
- `.MaterializeLastOrReasonWhyNotAsync()` -> `OneOf<T, NoElements>`
