### PR TITLE
🐛 Corrects `EntityFramework` Package References' Version Constraints

### DIFF
--- a/src/FGS.Linq.Extensions.EntityFramework6/FGS.Linq.Extensions.EntityFramework6.csproj
+++ b/src/FGS.Linq.Extensions.EntityFramework6/FGS.Linq.Extensions.EntityFramework6.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="EntityFramework" Version="[6.0.0, 6.3.0)" />
+    <PackageReference Include="EntityFramework" Version="[6.0.0, 6.5.0)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/src/FGS.Linq.Extensions.OneOf.EntityFramework6/FGS.Linq.Extensions.OneOf.EntityFramework6.csproj
+++ b/src/FGS.Linq.Extensions.OneOf.EntityFramework6/FGS.Linq.Extensions.OneOf.EntityFramework6.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <PackageReference Include="EntityFramework" Version="[6.0.0, 6.3.0)" />
+    <PackageReference Include="EntityFramework" Version="[6.0.0, 6.5.0)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">


### PR DESCRIPTION
Since all (current) versions of EF 6.x are supported on `net472`, we shouldn't exclude any of the range if we want to support such (which we do.)