### PR TITLE
🐛 Changes Documentation Deployment to `ubuntu-latest`

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy-docs:
 
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
 


### PR DESCRIPTION
"Container actions" are apparently only supported on Linux.