### PR TITLE
🐛 Changes `TargetFramework` of Documentation Surrogate CSPROJ

### DIFF
--- a/docs/Documentation.csproj
+++ b/docs/Documentation.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The `Documentation` project needs to be buildable on GitHub's `ubuntu-latest` (with .NET Core installed).