### PR TITLE
🐛📄 Improves Documentation Cross-References

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -68,6 +68,9 @@
     "noLangKeyword": false,
     "keepFileLink": false,
     "cleanupCacheHistory": false,
-    "disableGitFeatures": false
+    "disableGitFeatures": false,
+    "xrefService": [
+      "https://xref.docs.microsoft.com/query?uid={uid}"
+    ]
   }
 }

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -75,7 +75,8 @@
     "xref": [
       "./thirdPartyXref/autofac.yml",
       "./thirdPartyXref/moq.yml",
-      "./thirdPartyXref/oneof.yml"
+      "./thirdPartyXref/oneof.yml",
+      "./thirdPartyXref/rx.yml"
     ]
   }
 }

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -73,7 +73,8 @@
       "https://xref.docs.microsoft.com/query?uid={uid}"
     ],
     "xref": [
-      "./thirdPartyXref/autofac.yml"
+      "./thirdPartyXref/autofac.yml",
+      "./thirdPartyXref/moq.yml"
     ]
   }
 }

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -71,6 +71,9 @@
     "disableGitFeatures": false,
     "xrefService": [
       "https://xref.docs.microsoft.com/query?uid={uid}"
+    ],
+    "xref": [
+      "./thirdPartyXref/autofac.yml"
     ]
   }
 }

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -74,7 +74,8 @@
     ],
     "xref": [
       "./thirdPartyXref/autofac.yml",
-      "./thirdPartyXref/moq.yml"
+      "./thirdPartyXref/moq.yml",
+      "./thirdPartyXref/oneof.yml"
     ]
   }
 }

--- a/docs/thirdPartyXref/autofac.yml
+++ b/docs/thirdPartyXref/autofac.yml
@@ -1,0 +1,198 @@
+### YamlMime:XRefMap
+sorted: false
+references:
+
+- uid: Autofac
+  commentId: N:Autofac
+  fullName: Autofac
+  href: https://autofac.org/apidoc/html/8B9CDE3D.htm
+
+- uid: Autofac.ContainerBuilder
+  commentId: M:Autofac.ContainerBuilder
+  fullName: Autofac.ContainerBuilder
+  name: ContainerBuilder
+  nameWithType: ContainerBuilder
+  href: https://autofac.org/apidoc/html/717248.htm
+  summary: >
+    <p>Used to build an IContainer from component registrations.</p>
+
+- uid: Autofac.Builder
+  commentId: N:Autofac.Builder
+  fullName: Autofac.Builder
+  href: https://autofac.org/apidoc/html/4CEBBC9B.htm
+
+- uid: Autofac.Builder.IRegistrationBuilder`3
+  commentId: T:Autofac.Builder.IRegistrationBuilder`3
+  fullName: Autofac.Builder.IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle>
+  name: IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle>
+  nameWithType: IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle>
+  href: https://autofac.org/apidoc/html/AD021D47.htm
+  summary: >
+    <p>Data structure used to construct registrations.</p>
+
+- uid: Autofac.Builder.IRegistrationBuilder`3.InstancePerDependency
+  commentId: M:Autofac.Builder.IRegistrationBuilder`3.InstancePerDependency
+  fullName: Autofac.Builder.IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle>.InstancePerDependency
+  name: InstancePerDependency
+  nameWithType: IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle>.InstancePerDependency
+  href: https://autofac.org/apidoc/html/B7A3F094.htm
+  summary: >
+    <p>Configure the component so that every dependent component or call to Resolve() gets a new, unique instance (default).</p>
+
+- uid: Autofac.Builder.IRegistrationBuilder`3.InstancePerLifetimeScope
+  commentId: M:Autofac.Builder.IRegistrationBuilder`3.InstancePerLifetimeScope
+  fullName: Autofac.Builder.IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle>.InstancePerLifetimeScope
+  name: InstancePerLifetimeScope
+  nameWithType: IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle>.InstancePerLifetimeScope
+  href: https://autofac.org/apidoc/html/8804210E.htm
+  summary: >
+    <p>Configure the component so that every dependent component or call to Resolve() within a single ILifetimeScope gets the same, shared instance. Dependent components in different lifetime scopes will get different instances.</p>
+
+- uid: Autofac.Builder.IRegistrationBuilder`3.SingleInstance
+  commentId: M:Autofac.Builder.IRegistrationBuilder`3.SingleInstance
+  fullName: Autofac.Builder.IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle>.SingleInstance
+  name: SingleInstance
+  nameWithType: IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle>.SingleInstance
+  href: https://autofac.org/apidoc/html/49B17EDB.htm
+  summary: >
+    <p>Configure the component so that every dependent component or call to Resolve() gets the same, shared instance.</p>
+
+- uid: Autofac.Core
+  commentId: N:Autofac.Core
+  fullName: Autofac.Core
+  href: https://autofac.org/apidoc/html/D890DF6.htm
+
+- uid: Autofac.Core.IComponentRegistration
+  commentId: T:Autofac.Core.IComponentRegistration
+  fullName: Autofac.Core.IComponentRegistration
+  name: IComponentRegistration
+  nameWithType: IComponentRegistration
+  href: https://autofac.org/apidoc/html/39C18106.htm
+  summary: >
+    <p>Describes a logical component within the container.</p>
+
+- uid: Autofac.Core.IComponentRegistry
+  commentId: T:Autofac.Core.IComponentRegistry
+  fullName: Autofac.Core.IComponentRegistry
+  name: IComponentRegistry
+  nameWithType: IComponentRegistry
+  href: https://autofac.org/apidoc/html/D91152CD.htm
+  summary: >
+    <p>Provides component registrations according to the services they provide.</p>
+
+- uid: Autofac.Core.IModule
+  commentId: T:Autofac.Core.IModule
+  fullName: Autofac.Core.IModule
+  name: IModule
+  nameWithType: IModule
+  href: https://autofac.org/apidoc/html/11C538A3.htm
+  summary: >
+    <p>Represents a set of components and related functionality packaged together.</p>
+
+- uid: Autofac.Core.IModule.Configure(Autofac.Core.IComponentRegistry)
+  commentId: M:Autofac.Core.IModule.Configure(Autofac.Core.IComponentRegistry)
+  fullName: Autofac.Core.IModule.Configure(Autofac.Core.IComponentRegistry)
+  name: Configure(Autofac.Core.IComponentRegistry)
+  nameWithType: IModule.Configure(Autofac.Core.IComponentRegistry)
+  href: https://autofac.org/apidoc/html/6FD76F8B.htm
+  summary: >
+    <p>Apply the module to the component registry.</p>
+
+- uid: Autofac.Core.Service
+  commentId: T:Autofac.Core.Service
+  fullName: Autofac.Core.Service
+  name: Service
+  nameWithType: Service
+  href: https://autofac.org/apidoc/html/898E02E6.htm
+  summary: >
+    <p>Services are the lookup keys used to locate component instances.</p>
+
+- uid: Autofac.Features.Indexed.IIndex`2
+  commentId: T:Autofac.Features.Indexed.IIndex`2
+  fullName: Autofac.Features.Indexed.IIndex<TKey,TValue>
+  name: IIndex<TKey,TValue>
+  nameWithType: IIndex<TKey,TValue>
+  href: https://autofac.org/apidoc/html/8E58634B.htm
+  summary: >
+    <p>Provides components by lookup operations via an index (key) type.</p>
+
+- uid: Autofac.Module
+  commentId: T:Autofac.Module
+  fullName: Autofac.Module
+  name: Module
+  nameWithType: Module
+  href: https://autofac.org/apidoc/html/2A2437.htm
+  summary: >
+    <p>Base class for user-defined modules.</p>
+
+- uid: Autofac.Module.Load(Autofac.ContainerBuilder)
+  commentId: M:Autofac.Module.Load(Autofac.ContainerBuilder)
+  fullName: Autofac.Module.Load(Autofac.ContainerBuilder)
+  name: Load(Autofac.ContainerBuilder)
+  nameWithType: Module.Load(Autofac.ContainerBuilder)
+  href: https://autofac.org/apidoc/html/A4220791.htm
+  summary: >
+    <p>Override to add registrations to the container.</p>
+
+- uid: Autofac.Module.ThisAssembly
+  commentId: F:Autofac.Module.ThisAssembly
+  fullName: Autofac.Module.ThisAssembly
+  name: ThisAssembly
+  nameWithType: Module.ThisAssembly
+  href: https://autofac.org/apidoc/html/E657B0BB.htm
+  summary: >
+    <p>Gets the assembly in which the concrete module type is located. To avoid bugs whereby deriving from a module will change the target assembly, this property can only be used by modules that inherit directly from Module.</p>
+
+- uid: Autofac.Module.AttachToComponentRegistration(Autofac.Core.IComponentRegistry,Autofac.Core.IComponentRegistration)
+  commentId: M:Autofac.Module.AttachToComponentRegistration(Autofac.Core.IComponentRegistry,Autofac.Core.IComponentRegistration)
+  fullName: Autofac.Module.AttachToComponentRegistration(Autofac.Core.IComponentRegistry,Autofac.Core.IComponentRegistration)
+  name: AttachToComponentRegistration(Autofac.Core.IComponentRegistry,Autofac.Core.IComponentRegistration)
+  nameWithType: Module.AttachToComponentRegistration(Autofac.Core.IComponentRegistry,Autofac.Core.IComponentRegistration)
+  href: https://autofac.org/apidoc/html/DB09DDBB.htm
+  summary: >
+    <p>Override to attach module-specific functionality to a component registration.</p>
+
+- uid: Autofac.Module.AttachToRegistrationSource(Autofac.Core.IComponentRegistry,Autofac.Core.IRegistrationSource)
+  commentId: M:Autofac.Module.AttachToRegistrationSource(Autofac.Core.IComponentRegistry,Autofac.Core.IRegistrationSource)
+  fullName: Autofac.Module.AttachToRegistrationSource(Autofac.Core.IComponentRegistry,Autofac.Core.IRegistrationSource)
+  name: AttachToRegistrationSource(Autofac.Core.IComponentRegistry,Autofac.Core.IRegistrationSource)
+  nameWithType: Module.AttachToRegistrationSource(Autofac.Core.IComponentRegistry,Autofac.Core.IRegistrationSource)
+  href: https://autofac.org/apidoc/html/EA1B28AE.htm
+  summary: >
+    <p>Override to perform module-specific processing on a registration source.</p>
+
+- uid: Autofac.Module.Configure(Autofac.Core.IComponentRegistry)
+  commentId: M:Autofac.Module.Configure(Autofac.Core.IComponentRegistry)
+  fullName: Autofac.Module.Configure(Autofac.Core.IComponentRegistry)
+  name: Configure(Autofac.Core.IComponentRegistry)
+  nameWithType: Module.Configure(Autofac.Core.IComponentRegistry)
+  href: https://autofac.org/apidoc/html/11C538A3.htm
+  summary: >
+    <p>Apply the module to the component registry.</p>
+
+- uid: Autofac.IComponentContext
+  commentId: T:Autofac.IComponentContext
+  fullName: Autofac.IComponentContext
+  name: IComponentContext
+  nameWithType: IComponentContext
+  href: https://autofac.org/apidoc/html/D637B54C.htm
+  summary: >
+    <p>The context in which a service can be accessed or a component's dependencies resolved. Disposal of a context will dispose any owned components.</p>
+
+- uid: Autofac.Builder.SimpleActivatorData
+  commentId: T:Autofac.Builder.SimpleActivatorData
+  fullName: Autofac.Builder.SimpleActivatorData
+  name: SimpleActivatorData
+  nameWithType: SimpleActivatorData
+  href: https://autofac.org/apidoc/html/635A312A.htm
+  summary: >
+    <p>An activator builder with no parameters.</p>
+
+- uid: Autofac.Builder.SingleRegistrationStyle
+  commentId: T:Autofac.Builder.SingleRegistrationStyle
+  fullName: Autofac.Builder.SingleRegistrationStyle
+  name: SingleRegistrationStyle
+  nameWithType: SingleRegistrationStyle
+  href: https://autofac.org/apidoc/html/21851568.htm
+  summary: >
+    <p>Registration style for individual components.</p>

--- a/docs/thirdPartyXref/moq.yml
+++ b/docs/thirdPartyXref/moq.yml
@@ -1,0 +1,12 @@
+### YamlMime:XRefMap
+sorted: true
+references:
+
+- uid: Moq.Mock`1
+  commentId: T:Moq.Mock`1
+  fullName: Moq.Mock<T>
+  name: Mock<T>
+  nameWithType: Moq.Mock<T>
+  href: http://www.nudoq.org/#!/Packages/Moq/Moq/Mock(T)
+  summary: >
+    <p>Provides a mock implementation of T.</p>

--- a/docs/thirdPartyXref/oneof.yml
+++ b/docs/thirdPartyXref/oneof.yml
@@ -1,0 +1,84 @@
+### YamlMime:XRefMap
+sorted: true
+references:
+
+- uid: OneOf.OneOf`1
+  commentId: T:OneOf.OneOf`1
+  fullName: OneOf.OneOf<T0>
+  name: OneOf<T0>
+  nameWithType: OneOf<T0>
+  href: https://github.com/mcintyre321/OneOf
+  summary: >
+    <p>An F#-style discriminated union, which holds a single value.</p>
+
+- uid: OneOf.OneOf`2
+  commentId: T:OneOf.OneOf`2
+  fullName: OneOf.OneOf<T0,T1>
+  name: OneOf<T0,T1>
+  nameWithType: OneOf<T0,T1>
+  href: https://github.com/mcintyre321/OneOf
+  summary: >
+    <p>An F#-style discriminated union, which holds a single value.</p>
+
+- uid: OneOf.OneOf`3
+  commentId: T:OneOf.OneOf`3
+  fullName: OneOf.OneOf<T0,T1,T2>
+  name: OneOf<T0,T1,T2>
+  nameWithType: OneOf<T0,T1,T2>
+  href: https://github.com/mcintyre321/OneOf
+  summary: >
+    <p>An F#-style discriminated union, which holds a single value.</p>
+
+- uid: OneOf.OneOf`4
+  commentId: T:OneOf.OneOf`4
+  fullName: OneOf.OneOf<T0,T1,T2,T3>
+  name: OneOf<T0,T1,T2,T3>
+  nameWithType: OneOf<T0,T1,T2,T3>
+  href: https://github.com/mcintyre321/OneOf
+  summary: >
+    <p>An F#-style discriminated union, which holds a single value.</p>
+
+- uid: OneOf.OneOf`5
+  commentId: T:OneOf.OneOf`5
+  fullName: OneOf.OneOf<T0,T1,T2,T3,T4>
+  name: OneOf<T0,T1,T2,T3,T4>
+  nameWithType: OneOf<T0,T1,T2,T3,T4>
+  href: https://github.com/mcintyre321/OneOf
+  summary: >
+    <p>An F#-style discriminated union, which holds a single value.</p>
+
+- uid: OneOf.OneOf`6
+  commentId: T:OneOf.OneOf`6
+  fullName: OneOf.OneOf<T0,T1,T2,T3,T4,T5>
+  name: OneOf<T0,T1,T2,T3,T4,T5>
+  nameWithType: OneOf<T0,T1,T2,T3,T4,T5>
+  href: https://github.com/mcintyre321/OneOf
+  summary: >
+    <p>An F#-style discriminated union, which holds a single value.</p>
+
+- uid: OneOf.OneOf`7
+  commentId: T:OneOf.OneOf`7
+  fullName: OneOf.OneOf<T0,T1,T2,T3,T4,T5,T6>
+  name: OneOf<T0,T1,T2,T3,T4,T5,T6>
+  nameWithType: OneOf<T0,T1,T2,T3,T4,T5,T6>
+  href: https://github.com/mcintyre321/OneOf
+  summary: >
+    <p>An F#-style discriminated union, which holds a single value.</p>
+
+- uid: OneOf.OneOf`8
+  commentId: T:OneOf.OneOf`8
+  fullName: OneOf.OneOf<T0,T1,T2,T3,T4,T5,T6,T7>
+  name: OneOf<T0,T1,T2,T3,T4,T5,T6,T7>
+  nameWithType: OneOf<T0,T1,T2,T3,T4,T5,T6,T7>
+  href: https://github.com/mcintyre321/OneOf
+  summary: >
+    <p>An F#-style discriminated union, which holds a single value.</p>
+
+- uid: OneOf.OneOf`9
+  commentId: T:OneOf.OneOf`9
+  fullName: OneOf.OneOf<T0,T1,T2,T3,T4,T5,T6,T7,T8>
+  name: OneOf<T0,T1,T2,T3,T4,T5,T6,T7,T8>
+  nameWithType: OneOf<T0,T1,T2,T3,T4,T5,T6,T7,T8>
+  href: https://github.com/mcintyre321/OneOf
+  summary: >
+    <p>An F#-style discriminated union, which holds a single value.</p>

--- a/docs/thirdPartyXref/rx.yml
+++ b/docs/thirdPartyXref/rx.yml
@@ -1,0 +1,21 @@
+### YamlMime:XRefMap
+sorted: false
+references:
+
+- uid: System.Reactive.Timestamped`1
+  commentId: T:System.Reactive.Timestamped`1
+  fullName: System.Reactive.Timestamped<T>
+  name: Timestamped<T>
+  nameWithType: Timestamped<T>
+  href: http://www.nudoq.org/#!/Packages/Rx-Linq/System.Reactive.Linq/Timestamped(T)
+  summary: >
+    <p>Represents value with a timestamp on it. The timestamp typically represents the time the value was received, using an IScheduler's clock to obtain the current time.</p>
+
+- uid: System.Reactive.Concurrency.IScheduler
+  commentId: T:System.Reactive.Concurrency.IScheduler
+  fullName: System.Reactive.Concurrency.IScheduler
+  name: IScheduler
+  nameWithType: IScheduler
+  href: http://www.nudoq.org/#!/Packages/Rx-Interfaces/System.Reactive.Interfaces/IScheduler
+  summary: >
+    <p>Represents an object that schedules units of work.</p>

--- a/src/FGS.Autofac.Registration.Extensions/ContainerBuilderExtensions.cs
+++ b/src/FGS.Autofac.Registration.Extensions/ContainerBuilderExtensions.cs
@@ -73,7 +73,7 @@ namespace FGS.Autofac.Registration.Extensions
         /// <typeparam name="TKey">The type of keys in the index being wrapped.</typeparam>
         /// <typeparam name="TService">The type of services (values) in the index being wrapped.</typeparam>
         /// <param name="builder">The <see cref="ContainerBuilder"/> to add registrations to.</param>
-        /// <returns>The <see cref="IRegistrationBuilder{Func{TKey, TService}, SimpleActivatorData, SingleRegistrationStyle}"/>, so that additional registration calls can be chained.</returns>
+        /// <returns>The <see cref="IRegistrationBuilder{TLimit, TActivationData, TRegistrationStyle}"/>, so that additional registration calls can be chained.</returns>
         public static IRegistrationBuilder<Func<TKey, TService>, SimpleActivatorData, SingleRegistrationStyle> RegisterFactoryFromIndexLookup<TKey, TService>(this ContainerBuilder builder)
         {
             return builder.Register(CreateFactoryFromIndexLookup<TKey, TService>);

--- a/src/FGS.Tests.Support.AspNetCore.Mvc/Routing/MockUrlHelperExtensions.cs
+++ b/src/FGS.Tests.Support.AspNetCore.Mvc/Routing/MockUrlHelperExtensions.cs
@@ -22,7 +22,7 @@ namespace FGS.Tests.Support.AspNetCore.Mvc.Routing
         /// </summary>
         /// <param name="mockUrlHelper">The mock to add the invocation setup to.</param>
         /// <param name="routeName">The name of the route that invocations must match.</param>
-        /// <returns>Returns an <see cref="ISetup{IUrlHelper, string}"/> so that additional configuration calls can be chained.</returns>
+        /// <returns>Returns an <see cref="ISetup{TMock,TResult}"/> so that additional configuration calls can be chained.</returns>
         public static ISetup<IUrlHelper, string> SetupRouteUrl(this Mock<IUrlHelper> mockUrlHelper, string routeName)
         {
             var urlRouteContextPredicateExpression = UrlRouteContextPredicateLambdaExpressionFactory.Create(routeName);
@@ -37,7 +37,7 @@ namespace FGS.Tests.Support.AspNetCore.Mvc.Routing
         /// <param name="mockUrlHelper">The mock to add the invocation setup to.</param>
         /// <param name="routeName">The name of the route that invocations must match.</param>
         /// <param name="routeValues">The route values that invocations must match.</param>
-        /// <returns>Returns an <see cref="ISetup{IUrlHelper, string}"/> so that additional configuration calls can be chained.</returns>
+        /// <returns>Returns an <see cref="ISetup{TMock,TResult}"/> so that additional configuration calls can be chained.</returns>
         public static ISetup<IUrlHelper, string> SetupRouteUrl<TRouteValues>(this Mock<IUrlHelper> mockUrlHelper, string routeName, TRouteValues routeValues)
         {
             var urlRouteContextPredicateExpression = UrlRouteContextPredicateLambdaExpressionFactory.Create(routeName, routeValues);


### PR DESCRIPTION
This helps most of the documentation cross-references be resolved, which should help DocFx fill in a lot of the surprisingly-missing words in the documentation website.