### PR TITLE
✨👹 Adds Query Syntax for `OneOf` Discriminated Unions

### DIFF
--- a/FGS.Foundation.sln
+++ b/FGS.Foundation.sln
@@ -169,17 +169,19 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Linq.Extensions.EntityF
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FGS.Linq.Extensions.Pagination.EntityFramework.Shared", "src\FGS.Linq.Extensions.Pagination.EntityFramework.Shared\FGS.Linq.Extensions.Pagination.EntityFramework.Shared.shproj", "{96015FE6-1B5E-48F4-BCB3-464366C098F2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.Pagination.EntityFramework6", "src\FGS.Linq.Extensions.Pagination.EntityFramework6\FGS.Linq.Extensions.Pagination.EntityFramework6.csproj", "{8A64A5C6-2B3C-4BB2-B9FC-7C30B3F2B3E2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Linq.Extensions.Pagination.EntityFramework6", "src\FGS.Linq.Extensions.Pagination.EntityFramework6\FGS.Linq.Extensions.Pagination.EntityFramework6.csproj", "{8A64A5C6-2B3C-4BB2-B9FC-7C30B3F2B3E2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.Pagination.EntityFrameworkCore", "src\FGS.Linq.Extensions.Pagination.EntityFrameworkCore\FGS.Linq.Extensions.Pagination.EntityFrameworkCore.csproj", "{5B6E00E9-4217-45FB-93DA-0E822DC6B42D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Linq.Extensions.Pagination.EntityFrameworkCore", "src\FGS.Linq.Extensions.Pagination.EntityFrameworkCore\FGS.Linq.Extensions.Pagination.EntityFrameworkCore.csproj", "{5B6E00E9-4217-45FB-93DA-0E822DC6B42D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Collections.Extensions.OneOf.Units", "src\FGS.Collections.Extensions.OneOf.Units\FGS.Collections.Extensions.OneOf.Units.csproj", "{431C9136-225F-43FF-B11B-B5A597913166}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Collections.Extensions.OneOf.Units", "src\FGS.Collections.Extensions.OneOf.Units\FGS.Collections.Extensions.OneOf.Units.csproj", "{431C9136-225F-43FF-B11B-B5A597913166}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FGS.Linq.Extensions.OneOf.EntityFramework.Shared", "src\FGS.Linq.Extensions.OneOf.EntityFramework.Shared\FGS.Linq.Extensions.OneOf.EntityFramework.Shared.shproj", "{8A11571F-0DE7-4E1F-8C1D-6A441F3EAA85}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.OneOf.EntityFramework6", "src\FGS.Linq.Extensions.OneOf.EntityFramework6\FGS.Linq.Extensions.OneOf.EntityFramework6.csproj", "{037E878C-996E-4922-AC99-38DB0644CB79}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Linq.Extensions.OneOf.EntityFramework6", "src\FGS.Linq.Extensions.OneOf.EntityFramework6\FGS.Linq.Extensions.OneOf.EntityFramework6.csproj", "{037E878C-996E-4922-AC99-38DB0644CB79}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.Linq.Extensions.OneOf.EntityFrameworkCore", "src\FGS.Linq.Extensions.OneOf.EntityFrameworkCore\FGS.Linq.Extensions.OneOf.EntityFrameworkCore.csproj", "{19AC1E1D-73F5-4F74-8DC9-14E327933B3E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FGS.Linq.Extensions.OneOf.EntityFrameworkCore", "src\FGS.Linq.Extensions.OneOf.EntityFrameworkCore\FGS.Linq.Extensions.OneOf.EntityFrameworkCore.csproj", "{19AC1E1D-73F5-4F74-8DC9-14E327933B3E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FGS.OneOf.Extensions", "src\FGS.OneOf.Extensions\FGS.OneOf.Extensions.csproj", "{F0853018-F497-4395-8A25-9EA6D1BEB16B}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -509,6 +511,10 @@ Global
 		{19AC1E1D-73F5-4F74-8DC9-14E327933B3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19AC1E1D-73F5-4F74-8DC9-14E327933B3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{19AC1E1D-73F5-4F74-8DC9-14E327933B3E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0853018-F497-4395-8A25-9EA6D1BEB16B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0853018-F497-4395-8A25-9EA6D1BEB16B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0853018-F497-4395-8A25-9EA6D1BEB16B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0853018-F497-4395-8A25-9EA6D1BEB16B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -597,6 +603,7 @@ Global
 		{8A11571F-0DE7-4E1F-8C1D-6A441F3EAA85} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 		{037E878C-996E-4922-AC99-38DB0644CB79} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 		{19AC1E1D-73F5-4F74-8DC9-14E327933B3E} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
+		{F0853018-F497-4395-8A25-9EA6D1BEB16B} = {2FC8DF88-182F-4A79-9185-F242A6C12701}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9BE7FA6F-2D4E-4B5B-97B7-7D2DE8E3DB1E}

--- a/azure-pipelines/Master/BuildAndPushPackage.yml
+++ b/azure-pipelines/Master/BuildAndPushPackage.yml
@@ -70,6 +70,7 @@ parameters:
     67: FGS.Collections.Extensions.OneOf.Units
     68: FGS.Linq.Extensions.OneOf.EntityFramework6
     69: FGS.Linq.Extensions.OneOf.EntityFrameworkCore
+    70: FGS.OneOf.Extensions
 
 stages:
 

--- a/src/FGS.OneOf.Extensions/FGS.OneOf.Extensions.csproj
+++ b/src/FGS.OneOf.Extensions/FGS.OneOf.Extensions.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+
+    <Description>
+      Provides extension methods to augment OneOf's F#-style discriminated unions with the LINQ-like syntax introduced in Mark Seemann's "Humane Code" video series.
+      
+      Allows the use of multiple `OneOf` values in quick succession without large syntactic overhead.
+    </Description>
+    <PackageTags>discriminated unions;match;switch;humane;selectmany;bifold</PackageTags>
+
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OneOf" Version="[2.1.127, 3.0.0)" />
+    <PackageReference Include="System.Collections.Immutable" Version="[1.2.0, 2.0.0)" />
+  </ItemGroup>
+
+</Project>

--- a/src/FGS.OneOf.Extensions/OneOfExtensions.cs
+++ b/src/FGS.OneOf.Extensions/OneOfExtensions.cs
@@ -1,0 +1,25 @@
+using OneOf;
+using OneOf.Types;
+using System;
+
+namespace FGS.OneOf.Extensions
+{
+    public static class OneOfExtensions
+    {
+        public static OneOf<TSuccessNew, TError> ContinueOnSuccessWith<TSuccessOriginal, TError, TSuccessNew>(
+          this OneOf<TSuccessOriginal, TError> original,
+          Func<TSuccessOriginal, OneOf<TSuccessNew, TError>> continuation)
+        {
+            return original.Match(
+                originalSuccess => continuation(originalSuccess).Match<OneOf<TSuccessNew, TError>>(newSuccess => newSuccess, newError => newError),
+                originalError => originalError);
+        }
+
+        public static OneOf<TSuccess, Error<string>> SelectErrorString<TSuccess, TErrorOriginal>(
+            this OneOf<TSuccess, TErrorOriginal> source,
+            Func<TErrorOriginal, string> projection)
+        {
+            return source.SelectError(e => new Error<string>(projection(e)));
+        }
+    }
+}

--- a/src/FGS.OneOf.Extensions/OneOfQueryExpressionExtensions.cs
+++ b/src/FGS.OneOf.Extensions/OneOfQueryExpressionExtensions.cs
@@ -1,0 +1,64 @@
+using OneOf;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace FGS.OneOf.Extensions
+{
+    public static class OneOfQueryExpressionExtensions
+    {
+        public static OneOf<TSuccess, TErrorNew> SelectError<TSuccess, TErrorOriginal, TErrorNew>(
+            this OneOf<TSuccess, TErrorOriginal> source,
+            Func<TErrorOriginal, TErrorNew> projection)
+        {
+            return source.Match<OneOf<TSuccess, TErrorNew>>(success => success, error => projection(error));
+        }
+
+        public static OneOf<TSuccessNew, TError> Select<TSuccessOriginal, TSuccessNew, TError>(
+            this OneOf<TSuccessOriginal, TError> source,
+            Func<TSuccessOriginal, TSuccessNew> projection)
+        {
+            return source.Match<OneOf<TSuccessNew, TError>>(success => projection(success), error => error);
+        }
+
+        public static OneOf<TResult, TError> SelectMany<TSuccess1, TSuccess2, TError, TResult>(
+            this OneOf<TSuccess1, TError> source,
+            Func<TSuccess1, OneOf<TSuccess2, TError>> selector,
+            Func<TSuccess1, TSuccess2, TResult> resultSelector)
+        {
+            return source.Match(
+                sourceSuccess =>
+                    selector(sourceSuccess).Match<OneOf<TResult, TError>>(
+                        secondSuccess => resultSelector(sourceSuccess, secondSuccess),
+                        error => error),
+                error => error);
+        }
+
+        public static OneOf<IEnumerable<TResult>, TError> SelectMany<TSource, TSuccess, TError, TResult>(
+            this IEnumerable<TSource> source,
+            Func<TSource, OneOf<TSuccess, TError>> selector,
+            Func<TSource, TSuccess, TResult> resultSelector)
+        {
+            return source.Aggregate(
+                OneOf<ImmutableArray<TResult>, TError>.FromT0(ImmutableArray<TResult>.Empty),
+                (previousAggregate, currentItem) =>
+                    previousAggregate.Match(
+                        previousSuccesses => selector(currentItem).Match<OneOf<ImmutableArray<TResult>, TError>>(
+                            itemSuccess => previousSuccesses.Add(resultSelector(currentItem, itemSuccess)),
+                            itemError => itemError),
+                        previousError => previousError),
+                aggregate => aggregate.Match<OneOf<IEnumerable<TResult>, TError>>(allSuccesses => allSuccesses, error => error));
+        }
+
+        public static OneOf<TSuccess, TError> Flatten<TSuccess, TError>(this OneOf<OneOf<TSuccess, TError>, TError> source)
+        {
+            return source.Match(inner => inner.Match<OneOf<TSuccess, TError>>(success => success, error => error), error => error);
+        }
+
+        public static T Bifold<T>(this OneOf<T, T> source)
+        {
+            return source.Match(success => success, error => error);
+        }
+    }
+}


### PR DESCRIPTION
Adds helpers that give us LINQ-like syntax for using multiple `OneOf` values in succession without large syntactic overhead, inspired by Mark Seemann's "Humane Code" video series.

For more information, see: https://blog.ploeh.dk/2018/07/30/flattening-arrow-code-using-a-stack-of-monads/